### PR TITLE
Add Dockerfile and Jenkinsfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM folioci/openjdk8-jre:latest
+
+ENV VERTICLE_FILE mod-feesfines-fat.jar
+
+# Set the location of the verticles
+ENV VERTICLE_HOME /usr/verticles
+
+# Copy your fat jar to the container
+COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
+
+# Expose this port locally in the container.
+EXPOSE 8081

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,16 @@
+
+
+buildMvn {
+  publishModDescriptor = 'yes'
+  publishAPI = 'yes'
+  mvnDeploy = 'yes'
+
+  doDocker = {
+    buildJavaDocker {
+      publishMaster = 'yes'
+      healthChk = 'yes'
+      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+    }
+  }
+}
+


### PR DESCRIPTION
-  Add standard FOLIO Dockerfile (uses FOLIO Java 8 base image).   'docker' directory is not needed.
-  Add Jenkinsfile for Maven builds