### PR TITLE
[MODFEE-16] Error message not displaying when duplicate policy name entered

### DIFF
--- a/src/main/java/org/folio/rest/impl/OverdueFinePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OverdueFinePoliciesAPI.java
@@ -26,7 +26,7 @@ public class OverdueFinePoliciesAPI implements OverdueFinesPolicies {
     private static final String PRIMARY_KEY = "overdue_fine_policy_pkey";
     private static final Class<OverdueFinePolicy> OVERDUE_FINE_POLICY = OverdueFinePolicy.class;
     private static final String DUPLICATE_ENTITY_MESSAGE =
-            "An overdue fine policy with this name already exists. Please choose a different name.";
+            "The Overdue fine policy name entered already exists. Please enter a different name.";
 
     @Validate
     @Override

--- a/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
@@ -126,7 +126,7 @@ public class OverdueFinePoliciesAPITest {
     post(overdueFinePolicyEntity);
 
     JsonObject errorJson = new JsonObject()
-      .put("message", "An overdue fine policy with this name already exists. Please choose a different name.")
+      .put("message", "The Overdue fine policy name entered already exists. Please enter a different name.")
       .put("code", OverdueFinePoliciesAPI.DUPLICATE_ERROR_CODE)
       .put("parameters", new JsonArray());
 


### PR DESCRIPTION
**Purpose**
Change error message in `mod-feesfines` as per new requirements

**Link**
[MODFEE-16](https://issues.folio.org/browse/MODFEE-16)