### PR TITLE
MODFEE-23: Add sample overdue-fine and lost-item-fee policies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,22 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-reference-data</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/reference-data</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/reference-data</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/reference-data/lost-item-fees-policies/lost-item-fee-policy.json
+++ b/reference-data/lost-item-fees-policies/lost-item-fee-policy.json
@@ -1,0 +1,21 @@
+{
+  "id" : "ed892c0e-52e0-4cd9-8133-c0ef07b4a709",
+  "name" : "Lost item fee policy",
+  "description" : "Test lost item fee policy",
+  "chargeAmountItem" : {
+    "chargeType" : "actualCost",
+    "amount" : 0.0
+  },
+  "lostItemProcessingFee" : 0.0,
+  "chargeAmountItemPatron" : true,
+  "chargeAmountItemSystem" : true,
+  "lostItemChargeFeeFine" : {
+    "duration" : 2,
+    "intervalId" : "Days"
+  },
+  "returnedLostItemProcessingFee" : true,
+  "replacedLostItemProcessingFee" : true,
+  "replacementProcessingFee" : 0.0,
+  "replacementAllowed" : true,
+  "lostItemReturned" : "Charge"
+}

--- a/reference-data/overdue-fines-policies/overdue-fine-policy.json
+++ b/reference-data/overdue-fines-policies/overdue-fine-policy.json
@@ -1,0 +1,10 @@
+{
+  "id" : "cd3f6cac-fa17-4079-9fae-2fb28e521412",
+  "name" : "Overdue fine policy",
+  "description" : "Test overdue fine policy",
+  "countClosed" : true,
+  "maxOverdueFine" : 0.0,
+  "forgiveOverdueFine" : true,
+  "gracePeriodRecall" : true,
+  "maxOverdueRecallFine" : 0.0
+}

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -1,0 +1,53 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.utils.TenantLoading;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class TenantRefAPI extends TenantAPI {
+  private static final Logger log = LoggerFactory.getLogger(TenantRefAPI.class);
+
+  @Override
+  public void postTenant(TenantAttributes tenantAttributes,
+                         Map<String, String> headers,
+                         Handler<AsyncResult<Response>> handler, Context context) {
+
+    log.info("postTenant");
+    Vertx vertx = context.owner();
+    super.postTenant(tenantAttributes, headers, res -> {
+      if (res.failed()) {
+        handler.handle(res);
+        return;
+      }
+
+      TenantLoading tenantLoading = new TenantLoading();
+      tenantLoading.withKey("loadReference").withLead("reference-data")
+        .withIdContent()
+        .add("lost-item-fees-policies")
+        .add("overdue-fines-policies")
+        .perform(tenantAttributes, headers, vertx, performResponse -> {
+          if (performResponse.failed()) {
+            log.error("postTenant failure", performResponse.cause());
+
+            handler.handle(io.vertx.core.Future.succeededFuture(PostTenantResponse
+              .respond500WithTextPlain(performResponse.cause().getLocalizedMessage())));
+            return;
+          }
+
+          log.info("postTenant executed successfully");
+          handler.handle(io.vertx.core.Future.succeededFuture(PostTenantResponse
+            .respond201WithApplicationJson("")));
+        });
+    }, context);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/TenantRefAPITest.java
+++ b/src/test/java/org/folio/rest/impl/TenantRefAPITest.java
@@ -1,0 +1,119 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Collections;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.LostItemFeePolicies;
+import org.folio.rest.jaxrs.model.LostItemFeePolicy;
+import org.folio.rest.jaxrs.model.OverdueFinePolicies;
+import org.folio.rest.jaxrs.model.OverdueFinePolicy;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.utils.OkapiClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class TenantRefAPITest {
+  private static final int PORT = NetworkUtils.nextFreePort();
+  private static Vertx vertx;
+
+  private final OkapiClient okapiClient = new OkapiClient(PORT);
+
+  @BeforeClass
+  public static void setUpClass(final TestContext context) throws Exception {
+    Async async = context.async();
+    vertx = Vertx.vertx();
+
+    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+    final TenantClient tenantClient = createTenantClient();
+
+    DeploymentOptions restDeploymentOptions = new DeploymentOptions()
+      .setConfig(new JsonObject().put("http.port", PORT));
+
+    vertx.deployVerticle(RestVerticle.class.getName(), restDeploymentOptions,
+      res -> {
+        try {
+          tenantClient.postTenant(getTenantAttributes(), result -> async.complete());
+        } catch (Exception e) {
+          context.fail(e);
+        }
+      });
+  }
+
+  @AfterClass
+  public static void tearDownClass(final TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void overdueFinePolicyLoaded(TestContext context) {
+    succeededFuture(okapiClient.get("/overdue-fines-policies"))
+      .map(response -> response.as(OverdueFinePolicies.class))
+      .map(policy -> {
+        context.assertEquals(policy.getTotalRecords(), 1);
+
+        final OverdueFinePolicy overduePolicy = policy
+          .getOverdueFinePolicies().get(0);
+
+        // This id is used in mod-circulation-storage
+        // if you're going to change it,
+        // circulation rules must be updated as well
+        context.assertEquals(overduePolicy.getId(),
+          "cd3f6cac-fa17-4079-9fae-2fb28e521412");
+        return context;
+      }).setHandler(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void lostItemFeePolicyLoaded(TestContext context) {
+    succeededFuture(okapiClient.get("/lost-item-fees-policies"))
+      .map(response -> response.as(LostItemFeePolicies.class))
+      .map(policy -> {
+        context.assertEquals(policy.getTotalRecords(), 1);
+
+        final LostItemFeePolicy lostItemFeePolicy = policy
+          .getLostItemFeePolicies().get(0);
+
+        // This id is used in mod-circulation-storage
+        // if you're going to change it,
+        // circulation rules must be updated as well
+        context.assertEquals(lostItemFeePolicy.getId(),
+          "ed892c0e-52e0-4cd9-8133-c0ef07b4a709");
+        return context;
+      }).setHandler(context.asyncAssertSuccess());
+  }
+
+  private static TenantClient createTenantClient() {
+    return new TenantClient("http://localhost:" + PORT,
+      "test_tenant", "test_token");
+  }
+
+  private static TenantAttributes getTenantAttributes() {
+    final Parameter loadReferenceParameter = new Parameter()
+      .withKey("loadReference").withValue("true");
+
+    return new TenantAttributes()
+      .withModuleFrom("mod-feesfines:1.0")
+      .withModuleTo("mod-feesfines:2.0")
+      .withParameters(Collections.singletonList(loadReferenceParameter));
+  }
+}

--- a/src/test/java/org/folio/rest/utils/OkapiClient.java
+++ b/src/test/java/org/folio/rest/utils/OkapiClient.java
@@ -1,0 +1,37 @@
+package org.folio.rest.utils;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
+import javax.ws.rs.core.MediaType;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+public class OkapiClient {
+  private static final String TEST_TENANT = "test_tenant";
+  private static final String OKAPI_URL = "x-okapi-url";
+
+  private final String okapiUrl;
+
+  public OkapiClient(int okapiPort) {
+    this.okapiUrl = "http://localhost:" + okapiPort;
+  }
+
+  public Response get(String uri) {
+    return getRequestSpecification()
+      .when()
+      .get(uri);
+  }
+
+  private RequestSpecification getRequestSpecification() {
+    return RestAssured.given()
+      .baseUri(okapiUrl)
+      .contentType(MediaType.APPLICATION_JSON)
+      .header(new Header(OKAPI_HEADER_TENANT, TEST_TENANT))
+      .header(new Header(OKAPI_URL, okapiUrl))
+      .header(new Header(OKAPI_HEADER_TOKEN, "test_token"));
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODFEE-23: Create Overdue Fine Policy and Lost Item Policy - Test data for snapshot/testing environments.

* Add sample overdue and lost-item policies to use them in circulation rules.
* Add tenant API.