### PR TITLE
MODFEE-24: Set module version to 15.7.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-feesfines</artifactId>
-  <version>15.6.1-SNAPSHOT</version>
+  <version>15.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
https://issues.folio.org/browse/MODFEE-24: Incorrect next release version.

The [release guidelines](https://dev.folio.org/guidelines/release-procedures/#prepare-and-perform-the-source-release) state that the next release version should the next minor or major version.

The next release of mod-feesfines should be `15.7.0` or `16.0.0` not `15.6.1`.