### PR TITLE
MODFEE-25: Upgrade tenant API version to 1.2 to allow reference data upload.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -606,16 +606,16 @@
       ]
     },
     {
-      "id":"_tenant",
-      "version":"1.0",
-      "interfaceType":"system",
-      "handlers":[
+      "id" : "_tenant",
+      "version" : "1.2",
+      "interfaceType": "system",
+      "handlers": [
         {
-          "methods":[
-            "POST",
-            "DELETE"
-          ],
-          "pathPattern":"/_/tenant"
+          "methods": ["POST"],
+          "pathPattern": "/_/tenant"
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/_/tenant"
         }
       ]
     }

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -11,6 +11,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -23,6 +24,8 @@ public class TenantRefAPI extends TenantAPI {
                          Handler<AsyncResult<Response>> handler, Context context) {
 
     log.info("postTenant");
+    log.info("Tenant attributes: {}", JsonObject.mapFrom(tenantAttributes));
+
     Vertx vertx = context.owner();
     super.postTenant(tenantAttributes, headers, res -> {
       if (res.failed()) {


### PR DESCRIPTION
https://issues.folio.org/browse/MODFEE-25: Update tenant API version to 1.2

Updated `_tenant` API version to 1.2, because it is required to allow reference data uploading: https://github.com/folio-org/okapi/blob/master/doc/guide.md#tenant-parameters.