### PR TITLE
[MODFEE-21] Send patron notice for cancellation of fee/fine charge (due to error)

### DIFF
--- a/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
+++ b/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
@@ -12,7 +12,7 @@ public class FeeFineNoticeContext {
 
   private static final List<String> FEE_FINE_ACTION_TYPES = Arrays.asList(
     "Paid fully", "Paid partially", "Waived fully", "Waived partially",
-    "Transferred fully", "Transferred partially");
+    "Transferred fully", "Transferred partially", "Cancelled as error");
 
   private Owner owner;
   private Feefine feefine;
@@ -33,11 +33,11 @@ public class FeeFineNoticeContext {
   }
 
   public String getTemplateId() {
-    if (isCharge()) {
-      return getChargeNoticeTemplateId();
-    }
     if (isFeeFineActon()) {
       return getActionNoticeTemplateId();
+    }
+    else if (isCharge()) {
+      return getChargeNoticeTemplateId();
     }
     return null;
   }

--- a/src/main/java/org/folio/rest/service/PatronNoticeService.java
+++ b/src/main/java/org/folio/rest/service/PatronNoticeService.java
@@ -35,6 +35,7 @@ public class PatronNoticeService {
   private static final Logger logger = LoggerFactory.getLogger(PatronNoticeService.class);
 
   private static final String PATRON_COMMENTS_KEY = "PATRON";
+  private static final String STAFF_COMMENTS_KEY = "STAFF";
 
   private FeeFineRepository feeFineRepository;
   private OwnerRepository ownerRepository;
@@ -88,12 +89,13 @@ public class PatronNoticeService {
           .put("actionAmount", feefineaction.getAmountAction())
           .put("actionDateTime", actionDateTime)
           .put("balance", feefineaction.getBalance())
-          .put("actionAdditionalInfo", getAdditionalInfoForPatronFromFeeFineAction(feefineaction))));
+          .put("actionAdditionalInfo", getCommentsFromFeeFineAction(feefineaction, PATRON_COMMENTS_KEY))
+          .put("reasonForCancellation", getCommentsFromFeeFineAction(feefineaction, STAFF_COMMENTS_KEY))));
   }
 
-  private String getAdditionalInfoForPatronFromFeeFineAction(Feefineaction feefineaction) {
+  private String getCommentsFromFeeFineAction(Feefineaction feefineaction, String commentsKey){
     String comments = Optional.ofNullable(feefineaction.getComments()).orElse(StringUtils.EMPTY);
-    return parseFeeFineComments(comments).getOrDefault(PATRON_COMMENTS_KEY, StringUtils.EMPTY);
+    return parseFeeFineComments(comments).getOrDefault(commentsKey, StringUtils.EMPTY);
   }
 
   private void handleSendPatronNoticeResult(AsyncResult<Void> post) {

--- a/src/test/java/org/folio/PatronNoticeTest.java
+++ b/src/test/java/org/folio/PatronNoticeTest.java
@@ -130,7 +130,8 @@ class PatronNoticeTest {
         .put("actionAmount", 10.0)
         .put("actionDateTime", "2019-09-17T08:43:15.000+0000")
         .put("balance", 10.0)
-        .put("actionAdditionalInfo", "patron comment"));
+        .put("actionAdditionalInfo", "patron comment")
+        .put("reasonForCancellation", "staff comment"));
 
     JsonObject notice = new JsonObject()
       .put("recipientId", userId)
@@ -197,7 +198,8 @@ class PatronNoticeTest {
         .put("actionAmount", 10.0)
         .put("actionDateTime", "2019-09-17T08:43:15.000+0000")
         .put("balance", 10.0)
-        .put("actionAdditionalInfo", "patron comment"));
+        .put("actionAdditionalInfo", "patron comment")
+        .put("reasonForCancellation", "staff comment"));
 
     JsonObject notice = new JsonObject()
       .put("recipientId", userId)
@@ -263,7 +265,8 @@ class PatronNoticeTest {
         .put("actionAmount", 10.0)
         .put("actionDateTime", "2019-09-17T08:43:15.000+0000")
         .put("balance", 0.0)
-        .put("actionAdditionalInfo", "patron comment"));
+        .put("actionAdditionalInfo", "patron comment")
+        .put("reasonForCancellation", "staff comment"));
 
     JsonObject notice = new JsonObject()
       .put("recipientId", userId)
@@ -332,7 +335,8 @@ class PatronNoticeTest {
         .put("actionAmount", 10.0)
         .put("actionDateTime", "2019-09-17T08:43:15.000+0000")
         .put("balance", 0.0)
-        .put("actionAdditionalInfo", "patron comment"));
+        .put("actionAdditionalInfo", "patron comment")
+        .put("reasonForCancellation", "staff comment"));
 
     JsonObject notice = new JsonObject()
       .put("recipientId", userId)

--- a/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
+++ b/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
@@ -66,6 +66,7 @@ public class FeeFineNoticeContextTest {
     Feefineaction waivedPartially = createActionWithType("Waived partially");
     Feefineaction transferredFully = createActionWithType("Transferred fully");
     Feefineaction transferredPartially = createActionWithType("Transferred partially");
+    Feefineaction canceledAsError = createActionWithType("Cancelled as error");
 
     List<Object[]> parameters = new ArrayList<>();
 

--- a/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
+++ b/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
@@ -103,6 +103,11 @@ public class FeeFineNoticeContextTest {
       {owner, feeFineWithNoticeIds, transferredPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
+                     {owner, feeFineWithoutNoticeIds, canceledAsError, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+                     {owner, feeFineWithNoticeIds, canceledAsError, FEEFINE_ACTION_NOTICE_ID});
+
+    parameters.add(new Object[]
       {ownerWithoutDefaultNoticeIds, feeFineWithoutNoticeIds, charge, null});
 
     return parameters;

--- a/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
+++ b/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
@@ -66,7 +66,7 @@ public class FeeFineNoticeContextTest {
     Feefineaction waivedPartially = createActionWithType("Waived partially");
     Feefineaction transferredFully = createActionWithType("Transferred fully");
     Feefineaction transferredPartially = createActionWithType("Transferred partially");
-    Feefineaction canceledAsError = createActionWithType("Cancelled as error");
+    Feefineaction cancelledAsError = createActionWithType("Cancelled as error");
 
     List<Object[]> parameters = new ArrayList<>();
 
@@ -103,9 +103,9 @@ public class FeeFineNoticeContextTest {
       {owner, feeFineWithNoticeIds, transferredPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-                     {owner, feeFineWithoutNoticeIds, canceledAsError, DEFAULT_ACTION_NOTICE_ID});
+                     {owner, feeFineWithoutNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-                     {owner, feeFineWithNoticeIds, canceledAsError, FEEFINE_ACTION_NOTICE_ID});
+                     {owner, feeFineWithNoticeIds, cancelledAsError, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
       {ownerWithoutDefaultNoticeIds, feeFineWithoutNoticeIds, charge, null});

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -247,7 +247,8 @@ public class FeeFineActionsAPITest {
         .put("actionAmount", amountAction)
         .put("actionDateTime", dateAction)
         .put("balance", balance)
-        .put("actionAdditionalInfo", ""));
+        .put("actionAdditionalInfo", "")
+        .put("reasonForCancellation","for staff"));
   }
 
   private String createFeeFineActionJson(String dateAction, String typeAction,

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -247,8 +247,8 @@ public class FeeFineActionsAPITest {
         .put("actionAmount", amountAction)
         .put("actionDateTime", dateAction)
         .put("balance", balance)
-        .put("actionAdditionalInfo", "")
-        .put("reasonForCancellation","for staff"));
+        .put("actionAdditionalInfo", "patron comment")
+        .put("reasonForCancellation", "staff comment"));
   }
 
   private String createFeeFineActionJson(String dateAction, String typeAction,
@@ -258,7 +258,7 @@ public class FeeFineActionsAPITest {
     return new JsonObject()
       .put("dateAction", dateAction)
       .put("typeAction", typeAction)
-      .put("comments", "STAFF : for staff")
+      .put("comments", "STAFF : staff comment \n PATRON : patron comment")
       .put("notify", notify)
       .put("amountAction", amountAction)
       .put("balance", balance)


### PR DESCRIPTION
**Purpose**
Enable sending of patron notices for error.

**Approach**
Extend the list of fee/fine actions with error.
Add token "fee.reasonForCancellation" to template

**Links**
[MODFEE-21](https://issues.folio.org/browse/MODFEE-21)