### PR TITLE
[MODFEE-34] Can't save Overdue fine policy

### DIFF
--- a/ramls/quantity.json
+++ b/ramls/quantity.json
@@ -4,9 +4,8 @@
   "type": "object",
   "properties": {
     "quantity": {
-      "description": "Quantity of the number of times the interval repeats",
-      "type": "number",
-      "minimum": 1.0
+      "description": "Recurring fine amount",
+      "type": "number"
     },
     "intervalId": {
       "description": "Interval for the period, e.g. hour, day, week, month or year",

--- a/ramls/quantity.json
+++ b/ramls/quantity.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "quantity": {
-      "description": "Recurring fine amount",
+      "description": "Fine amount per interval",
       "type": "number"
     },
     "intervalId": {

--- a/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
@@ -202,6 +202,18 @@ public class OverdueFinePoliciesAPITest {
     okapiTenant = originalTenant;
   }
 
+  @Test
+  public void postOverdueFinePolicyWithZeroFineAmount() {
+    JsonObject entityJson = createEntityJson();
+    entityJson.getJsonObject("overdueFine").put("quantity", 0);
+    entityJson.getJsonObject("overdueRecallFine").put("quantity", 0);
+
+    post(entityJson.encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .contentType(ContentType.JSON);
+  }
+
   private Response post(String body) {
     return getRequestSpecification()
       .body(body)


### PR DESCRIPTION
**Purpose**
Fix `OverdueFinePolicy` validation for entities with fine amounts < 1.

**Approach**
Remove minimum value constraint from JSON-schema.

This resolves [MODFEE-34](https://issues.folio.org/browse/MODFEE-34).