### PR TITLE
[MODFEE-38] Enabled patron notices sending for refunds

### DIFF
--- a/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
+++ b/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
@@ -11,8 +11,11 @@ import org.folio.rest.jaxrs.model.Owner;
 public class FeeFineNoticeContext {
 
   private static final List<String> FEE_FINE_ACTION_TYPES = Arrays.asList(
-    "Paid fully", "Paid partially", "Waived fully", "Waived partially",
-    "Transferred fully", "Transferred partially", "Cancelled as error");
+    "Paid fully", "Paid partially",
+    "Waived fully", "Waived partially",
+    "Transferred fully", "Transferred partially",
+    "Refunded fully", "Refunded partially",
+    "Cancelled as error");
 
   private Owner owner;
   private Feefine feefine;

--- a/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
+++ b/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
@@ -66,6 +66,8 @@ public class FeeFineNoticeContextTest {
     Feefineaction waivedPartially = createActionWithType("Waived partially");
     Feefineaction transferredFully = createActionWithType("Transferred fully");
     Feefineaction transferredPartially = createActionWithType("Transferred partially");
+    Feefineaction refundedFully = createActionWithType("Refunded fully");
+    Feefineaction refundedPartially = createActionWithType("Refunded partially");
     Feefineaction cancelledAsError = createActionWithType("Cancelled as error");
 
     List<Object[]> parameters = new ArrayList<>();
@@ -103,9 +105,18 @@ public class FeeFineNoticeContextTest {
       {owner, feeFineWithNoticeIds, transferredPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-                     {owner, feeFineWithoutNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithoutNoticeIds, refundedFully, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-                     {owner, feeFineWithNoticeIds, cancelledAsError, FEEFINE_ACTION_NOTICE_ID});
+      {owner, feeFineWithoutNoticeIds, refundedPartially, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithNoticeIds, refundedFully, FEEFINE_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithNoticeIds, refundedPartially, FEEFINE_ACTION_NOTICE_ID});
+
+    parameters.add(new Object[]
+      {owner, feeFineWithoutNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithNoticeIds, cancelledAsError, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
       {ownerWithoutDefaultNoticeIds, feeFineWithoutNoticeIds, charge, null});


### PR DESCRIPTION
**Purpose**
Enable patron notices sending for Refunds.

**Approach**
Entend the list of fee/fine actions eligible for sending patron notices in `FeeFineNoticeContext`.

**Links**
Resolves [MODFEE-38](https://issues.folio.org/browse/MODFEE-38).