### PR TITLE
[MODFEE-41] Patron notices for actions and charges are not sent when templateId is an empty String

### DIFF
--- a/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
+++ b/src/main/java/org/folio/rest/domain/FeeFineNoticeContext.java
@@ -1,5 +1,7 @@
 package org.folio.rest.domain;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,15 +56,11 @@ public class FeeFineNoticeContext {
   }
 
   private String getChargeNoticeTemplateId() {
-    return feefine.getChargeNoticeId() != null
-      ? feefine.getChargeNoticeId()
-      : owner.getDefaultChargeNoticeId();
+    return defaultIfBlank(feefine.getChargeNoticeId(), owner.getDefaultChargeNoticeId());
   }
 
   private String getActionNoticeTemplateId() {
-    return feefine.getActionNoticeId() != null
-      ? feefine.getActionNoticeId()
-      : owner.getDefaultActionNoticeId();
+    return defaultIfBlank(feefine.getActionNoticeId(), owner.getDefaultActionNoticeId());
   }
 
   public String getUserId() {

--- a/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
+++ b/src/test/java/org/folio/rest/domain/FeeFineNoticeContextTest.java
@@ -51,10 +51,15 @@ public class FeeFineNoticeContextTest {
       .withChargeNoticeId(FEEFINE_CHARGE_NOTICE_ID)
       .withActionNoticeId(FEEFINE_ACTION_NOTICE_ID);
 
-    Feefine feeFineWithoutNoticeIds = new Feefine()
+    Feefine feeFineWithNullNoticeIds = new Feefine()
       .withFeeFineType("Test charge")
       .withChargeNoticeId(null)
       .withActionNoticeId(null);
+
+    Feefine feeFineWithEmptyNoticeIds = new Feefine()
+      .withFeeFineType("Test charge")
+      .withChargeNoticeId("")
+      .withActionNoticeId("");
 
     Feefineaction charge = new Feefineaction()
       .withPaymentMethod(null)
@@ -73,53 +78,75 @@ public class FeeFineNoticeContextTest {
     List<Object[]> parameters = new ArrayList<>();
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, charge, DEFAULT_CHARGE_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, charge, DEFAULT_CHARGE_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, charge, DEFAULT_CHARGE_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, charge, FEEFINE_CHARGE_NOTICE_ID});
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, paidFully, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, paidFully, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, paidPartially, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, paidPartially, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, paidFully, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, paidPartially, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, paidFully, FEEFINE_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, paidPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, waivedFully, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, waivedFully, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, waivedPartially, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, waivedPartially, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, waivedFully, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, waivedPartially, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, waivedFully, FEEFINE_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, waivedPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, transferredFully, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, transferredFully, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, transferredPartially, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, transferredPartially, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, transferredFully, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, transferredPartially, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, transferredFully, FEEFINE_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, transferredPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, refundedFully, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, refundedFully, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, refundedPartially, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, refundedPartially, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, refundedFully, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, refundedPartially, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, refundedFully, FEEFINE_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, refundedPartially, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-      {owner, feeFineWithoutNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
+      {owner, feeFineWithNullNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
+    parameters.add(new Object[]
+      {owner, feeFineWithEmptyNoticeIds, cancelledAsError, DEFAULT_ACTION_NOTICE_ID});
     parameters.add(new Object[]
       {owner, feeFineWithNoticeIds, cancelledAsError, FEEFINE_ACTION_NOTICE_ID});
 
     parameters.add(new Object[]
-      {ownerWithoutDefaultNoticeIds, feeFineWithoutNoticeIds, charge, null});
+      {ownerWithoutDefaultNoticeIds, feeFineWithNullNoticeIds, charge, null});
+    parameters.add(new Object[]
+      {ownerWithoutDefaultNoticeIds, feeFineWithEmptyNoticeIds, charge, null});
 
     return parameters;
   }


### PR DESCRIPTION
**Porpose**
Fix incorrect treatment of empty template IDs for action-based patron notices, which causes failures in `mod-notify` and results in patron notice emails not being delivered.

**Approach**
Removing custom templates from an existing fee/fine type on the UI results in their IDs not being removed, but saved as empty strings (`""`). These empty IDs should be treated as absent in `mod-feesfines`. The root cause of the issue will be handled in [UIU-1546](https://issues.folio.org/browse/UIU-1546).

**Links**
This PR resolves [MODFEE-41](https://issues.folio.org/browse/MODFEE-41).
UI part of the fix - [UIU-1546](https://issues.folio.org/browse/UIU-1546).