### PR TITLE
MODFEE-48 Add new fields fields to account

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,12 +5,20 @@
     {
       "id": "patron-notice",
       "version": "1.0"
+    },
+    {
+      "id": "inventory",
+      "version": "10.2"
+    },
+    {
+      "id": "holdings-storage",
+      "version": "4.2"
     }
   ],
   "provides":[
     {
       "id":"feesfines",
-      "version":"15.1",
+      "version":"15.2",
       "handlers":[
         {
           "methods":[

--- a/ramls/accountdata.json
+++ b/ramls/accountdata.json
@@ -131,6 +131,18 @@
     "id": {
       "description": "User fine/fee account id, UUID",
       "type": "string"
+    },
+    "holdingsRecordId": {
+      "description": "Item field: item.holdingsRecordId",
+      "type": "string",
+      "readonly": true,
+      "$ref": "uuid.json"
+    },
+    "instanceId": {
+      "description": "Holdings record field: holdingsRecord.instanceId",
+      "type": "string",
+      "readonly": true,
+      "$ref": "uuid.json"
     }
   },
   "additionalProperties": false,

--- a/ramls/accounts.raml
+++ b/ramls/accounts.raml
@@ -12,6 +12,10 @@ types:
   accountdataCollection: !include accountdataCollection.json
   errors: !include raml-util/schemas/errors.schema
   patronNotice: !include patronNotice.json
+  item: !include item.json
+  items: !include items.json
+  holdingsRecord: !include holdings-record.json
+  holdingsRecords: !include holdings-records.json
 
 traits:
   orderable: !include raml-util/traits/orderable.raml

--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A holdings record",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "the system assigned unique ID of the holdings record; UUID",
+      "$ref": "uuid.json"
+    },
+    "hrid": {
+      "type": "string",
+      "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
+    },
+    "holdingsTypeId": {
+      "type": "string",
+      "description": "unique ID for the type of this holdings record, a UUID",
+      "$ref": "uuid.json"
+    },
+    "formerIds": {
+      "type": "array",
+      "description": "Previous ID(s) assigned to the holdings record",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "instanceId": {
+      "type": "string",
+      "$ref": "uuid.json"
+    },
+    "permanentLocationId": {
+      "type": "string",
+      "description": "The permanent shelving location in which an item resides.",
+      "$ref" : "uuid.json"
+    },
+    "temporaryLocationId": {
+      "type": "string",
+      "description": "Temporary location is the temporary location, shelving location, or holding which is a physical place where items are stored, or an Online location.",
+      "$ref": "uuid.json"
+    },
+    "electronicAccess": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "uniform resource identifier (URI) is a string of characters designed for unambiguous identification of resources"
+          },
+          "linkText": {
+            "type": "string",
+            "description": "the value of the MARC tag field 856 2nd indicator, where the values are: no information provided, resource, version of resource, related resource, no display constant generated"
+          },
+          "materialsSpecification": {
+            "type": "string",
+            "description": "materials specified is used to specify to what portion or aspect of the resource the electronic location and access information applies (e.g. a portion or subset of the item is electronic, or a related electronic resource is being linked to the record)"
+          },
+          "publicNote": {
+            "type": "string",
+            "description": "URL public note to be displayed in the discovery"
+          },
+          "relationshipId": {
+            "type": "string",
+            "description": "relationship between the electronic resource at the location identified and the item described in the record as a whole"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "uri"
+        ]
+      }
+    },
+    "callNumberTypeId": {
+      "type": "string",
+      "description": "unique ID for the type of call number on a holdings record, a UUID",
+      "$ref": "uuid.json"
+    },
+    "callNumberPrefix": {
+      "type": "string",
+      "description": "Prefix of the call number on the holding level."
+    },
+    "callNumber": {
+      "type": "string",
+      "description": "Call Number is an identifier assigned to an item, usually printed on a label attached to the item."
+    },
+    "callNumberSuffix": {
+      "type": "string",
+      "description": "Suffix of the call number on the holding level."
+    },
+    "shelvingTitle": {
+      "type": "string",
+      "description": "Indicates the shelving form of title."
+    },
+    "acquisitionFormat": {
+      "type": "string"
+    },
+    "acquisitionMethod": {
+      "type": "string"
+    },
+    "receiptStatus": {
+      "type": "string",
+      "description": "Receipt status (e.g. pending, awaiting receipt, partially received, fully received, receipt not required, and cancelled)"
+    },
+    "notes": {
+      "type": "array",
+      "description": "Notes about action, copy, binding etc.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "holdingsNoteTypeId": {
+            "type": "string",
+            "description": "ID of the type of note",
+            "$ref" : "uuid.json"
+          },
+          "note": {
+            "type": "string",
+            "description": "Text content of the note"
+          },
+          "staffOnly": {
+            "type": "boolean",
+            "description": "If true, determines that the note should not be visible for others than staff",
+            "default": false
+          }
+        }
+      }
+    },
+    "illPolicyId": {
+      "type": "string",
+      "description": "unique ID for an ILL policy, a UUID",
+      "$ref" : "uuid.json"
+    },
+    "illPolicy": {
+      "type": "object",
+      "description": "expanded ILL Policy object corresponding to illPolicyId",
+      "javaType": "org.folio.rest.jaxrs.model.IllPolicyVirtual",
+      "folio:$ref": "illpolicy.json",
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "ill-policies",
+      "folio:linkFromField": "illPolicyId",
+      "folio:linkToField": "id",
+      "folio:includedElement": "illPolicies.0"
+    },
+    "retentionPolicy": {
+      "type": "string",
+      "description": "Records information regarding how long we have agreed to keep something."
+    },
+    "digitizationPolicy": {
+      "type": "string"
+    },
+    "holdingsStatements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "statement": {
+            "type": "string",
+            "description": "Specifices the exact content to which the library has access, typically for continuing publications."
+          },
+          "note": {
+            "type": "string",
+            "description": "Note attached to a holdings statement"
+          }
+        }
+      }
+    },
+    "holdingsStatementsForIndexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "statement": {
+            "type": "string",
+            "description": "Textual description of the holdings of indexes"
+          },
+          "note": {
+            "type": "string",
+            "description": "Note attached to a holdings statement"
+          }
+        }
+      }
+    },
+    "holdingsStatementsForSupplements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "statement": {
+            "type": "string",
+            "description": "textual description of the holdings of supplementary material"
+          },
+          "note": {
+            "type": "string",
+            "description": "note attached to a holdings statement"
+          }
+        }
+      }
+    },
+    "copyNumber": {
+      "type": "string",
+      "description": "Item/Piece ID (usually barcode) for systems that do not use item records. Ability to designate the copy number if institution chooses to use copy numbers."
+    },
+    "numberOfItems": {
+      "type": "string",
+      "description": "Text (Number)"
+    },
+    "receivingHistory": {
+      "type": "object",
+      "properties": {
+        "displayType": {
+          "type": "string",
+          "description": "Display hint. 1: Display fields separately. 2: Display fields concatenated"
+        },
+        "entries": {
+          "type": "array",
+          "description": ".",
+          "items": {
+            "type": "object",
+            "properties": {
+              "publicDisplay": {
+                "type": "boolean",
+                "description": "Defines if the receivingHistory should be visible to the public."
+              },
+              "enumeration": {
+                "type": "string",
+                "description": "This is the volume/issue number (e.g. v.71:no.6-2)"
+              },
+              "chronology": {
+                "type": "string",
+                "description": "Repeated element from Receiving history - Enumeration AND Receiving history - Chronology"
+              }
+            }
+          }
+        }
+      }
+    },
+    "discoverySuppress": {
+      "type": "boolean",
+      "description": "records the fact that the record should not be displayed in a discovery system"
+    },
+    "statisticalCodeIds": {
+      "type": "array",
+      "description": "List of statistical code IDs",
+      "items": {
+        "type": "string",
+        "$ref" : "uuid.json"
+      },
+      "uniqueItems": true
+    },
+    "holdingsItems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "item.json"
+      },
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "inventory/items",
+      "folio:linkFromField": "id",
+      "folio:linkToField": "holdingsRecordId",
+      "folio:includedElement": "items"
+    },
+    "holdingsInstance": {
+      "type": "object",
+      "folio:$ref": "instance.json",
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "inventory/instances",
+      "folio:linkFromField": "instanceId",
+      "folio:linkToField": "id",
+      "folio:includedElement": "instances.0"
+    },
+    "tags": {
+      "description": "arbitrary tags associated with this holding",
+      "id": "tags",
+      "type": "object",
+      "$ref": "raml-util/schemas/tags.schema"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "instanceId",
+    "permanentLocationId"
+  ]
+}

--- a/ramls/holdings-records.json
+++ b/ramls/holdings-records.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of holdings records",
+  "type": "object",
+  "properties": {
+    "holdingsRecords": {
+      "description": "List of holdings records",
+      "id": "holdingsRecord",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "holdings-record.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    },
+    "resultInfo": {
+      "$ref": "raml-util/schemas/resultInfo.schema",
+      "readonly": true
+    }
+  },
+  "required": [
+    "holdingsRecords",
+    "totalRecords"
+  ]
+}

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -1,0 +1,473 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An item record",
+  "type": "object",
+  "properties": {
+    "links": {
+      "type": "object"
+    },
+    "id": {
+      "description": "Item id",
+      "type": "string"
+    },
+    "hrid": {
+      "type": "string",
+      "description": "The human readable ID, also called eye readable ID. A system-assigned sequential alternate ID"
+    },
+    "holdingsRecordId": {
+      "description": "ID of the holdings record the item is a member of",
+      "type": "string"
+    },
+    "formerIds": {
+      "type": "array",
+      "description": "Previous identifiers assigned to the item",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "discoverySuppress": {
+      "type": "boolean",
+      "description": "Records the fact that the record should not be displayed in a discovery system"
+    },
+    "title": {
+      "type": "string",
+      "description": "Resouce title (read only, inherited from associated instance record)",
+      "readonly": true
+    },
+    "contributorNames": {
+      "description": "A list of contributor names",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The contributor name",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "callNumber": {
+      "type": "string",
+      "description": "Call number is an identifier assigned to an item, usually printed on a label attached to the item, and used to determine its physical position in a shelving sequence (e.g. K1 .M44, read only, inherited from associated holdings record)",
+      "readonly": true
+    },
+    "barcode": {
+      "description": "Text, with input likely validated by the barcode scanner",
+      "type": "string"
+    },
+    "accessionNumber": {
+      "type": "string",
+      "description": "Accession number is also called inventar number. Accession number is a unique number assigned to an item in the order in which it is added to a library collection. Most libraries assign accession numbers in continous numerical sequece, but some use a code system to indicate type of material and/or year of accession in addition to order of accession"
+    },
+
+    "itemLevelCallNumber": {
+      "description": "Call number is an identifier assigned to an item, usually printed on a label attached to the item, and used to determine its physical position in a shelving sequence (e.g. K1 .M44, read only, inherited from associated holdings record). The item level call number, is the call number on item level",
+      "type": "string"
+    },
+    "itemLevelCallNumberPrefix": {
+      "description": "Prefix of the call number on the item level",
+      "type": "string"
+    },
+    "itemLevelCallNumberSuffix": {
+      "description": "Suffix of the call number on the item level",
+      "type": "string"
+    },
+    "itemLevelCallNumberTypeId": {
+      "description": "Call number type, refers to a call-number-type reference record",
+      "type": "string"
+    },
+    "effectiveCallNumberComponents": {
+      "type": "object",
+      "description": "Elements of a full call number generated from the item or holding",
+      "properties": {
+        "callNumber": {
+          "type": "string",
+          "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        },
+        "suffix": {
+          "type": "string",
+          "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        },
+        "typeId": {
+          "type": "string",
+          "description": "Effective Call Number Type Id is the call number type id assigned to the item or associated holding.",
+          "$ref": "uuid.json",
+          "readonly": true
+        }
+      }
+    },
+    "volume": {
+      "description": "Volume is intended for monographs when a multipart monograph (e.g. a biography of Gerorge Bernard Shaw in three volumes)",
+      "type": "string"
+    },
+    "enumeration": {
+      "description": "Enumeration is the descriptive information for the numbering scheme of a serial, usually identified by level and a descriptive caption, e.g., level 0 = v. and level 1 = no. This means that each issue of the serial has a volume and an issue number that would appear (e.g. v.71:no.6-2)",
+      "type": "string"
+    },
+    "chronology": {
+      "description": "Chronology is the descriptive information for the dating scheme of a serial, usually identified by level, e.g., level 0 = year level 1 = month. This means that each issue of the serial has a month and a year on each issue (e.g. 1985:July-Dec.)",
+      "type": "string"
+    },
+    "yearCaption": {
+      "description": "In multipart monographs, a caption is characters used to label a level of chronology (e.g. 'year 1985')",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "itemIdentifier": {
+      "description": "Item identifier number, e.g. imported from the union catalogue (read only)",
+      "type": "string"
+    },
+    "copyNumber": {
+      "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; a copy of a multi-volume, (e.g. Copy 1, or C.7.)",
+      "type": "string"
+    },
+    "numberOfPieces": {
+      "description": "Number of pieces. Used when an item is checked out or returned to verify that all parts are present (e.g. 7 CDs in a set)",
+      "type": "string"
+    },
+    "descriptionOfPieces": {
+      "description": "Text which descripe the pieces",
+      "type": "string"
+    },
+    "numberOfMissingPieces": {
+      "description": "Number of missing pieces",
+      "type": "string"
+    },
+    "missingPieces": {
+      "description": "Text which descripes the missing pieces",
+      "type": "string"
+    },
+    "missingPiecesDate": {
+      "description": "Date when the piece(s) went missing",
+      "type": "string"
+    },
+    "itemDamagedStatusId": {
+      "description": "Item Damage status Id, refers to an Item damage Status ID reference record",
+      "type": "string"
+    },
+    "itemDamagedStatusDate": {
+      "description": "Date when damage status was last changed",
+      "type": "string"
+    },
+    "notes": {
+      "description": "notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "itemNoteTypeId": {
+            "description": "Item note type, refers to a item-note-type reference record",
+            "type": "string"
+          },
+          "note": {
+            "description": "Text to display (e.g. action note, binding, use and reproduction)",
+            "type": "string"
+          },
+          "staffOnly": {
+            "description": "Records the fact that the record should only be displayed for staff",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "circulationNotes": {
+      "type": "array",
+      "description": "Notes to be displayed in circulation processes",
+      "items": {
+        "type": "object",
+        "properties": {
+          "noteType": {
+            "type": "string",
+            "description": "Type of circulation process that the note applies to",
+            "enum": ["Check in", "Check out"]
+          },
+          "note": {
+            "type": "string",
+            "description": "Text to display"
+          },
+          "staffOnly": {
+            "type": "boolean",
+            "description": "Records the fact that the note should only be displayed for staff",
+            "default": false
+          },
+          "source": {
+            "type": "object",
+            "description": "The user who added/updated the note. The property is generated by the server and needed to support sorting.",
+            "readonly": true,
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The id of the user who added/updated the note",
+                "readonly": true
+              },
+              "personal": {
+                "type": "object",
+                "description": "Personal information about the user",
+                "readonly": true,
+                "properties": {
+                  "lastName": {
+                    "type": "string",
+                    "description": "The user's last name",
+                    "readonly": true
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The user's first name",
+                    "readonly": true
+                  }
+                }
+              }
+            }
+          },
+          "date": {
+            "type": "string",
+            "description": "Date and time the record is added/updated. The property is generated by the server and needed to support sorting.",
+            "readonly": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "status": {
+      "description": "The status of the item",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the item state (e.g. Available, Checked out, In transit, Awaiting pickup, On order). Default value is set to: Available",
+          "type": "string",
+          "enum": [
+            "Available",
+            "Awaiting pickup",
+            "Awaiting delivery",
+            "Checked out",
+            "In process",
+            "In transit",
+            "Missing",
+            "On order",
+            "Paged",
+            "Declared lost",
+            "Order closed",
+            "Claimed returned"
+          ]
+        },
+        "date": {
+          "description": "Date of the current item state. E.g. date set when item state was changed by the Check out app",
+          "type": "string",
+          "readonly": true,
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ]
+    },
+    "materialType": {
+      "description": "Material type define what type of thing the item is",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Material type Id, refers to a material type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Material type name (e.g. Audio book, Audio disc, Computer file, Pamphelet) ",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "permanentLoanType": {
+      "description": "Permanent loan type, is the default loan type for a given item. Loan types are tenant-defined in a reference table in Settings, Inventory, Item, Loan type (e.g. Can circulate, Course reserves, Reading room, Selected)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Permanent loan type Id, refers to a loan type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Permanent loan type name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "temporaryLoanType": {
+      "description": "Temporary loan type, is the temporary loan type for a given item. Loan types are tenant-defined in a reference table in Settings, Inventory, Item, Loan type (e.g. Can circulate, Course reserves, Reading room, Selected)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Temporary loan type Id, refers to a loan type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Temporary loan type name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "permanentLocation": {
+      "description": "Permanent item location is the default location, shelving location, or holding which is a physical place where items are stored, or an Online location. The location is defined by Institutions, Campuses, libraries, and locations. Permanent location can be assigned at the holding level, and be overridden at the item level if needed",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Permanent location Id, refers to a location type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Permanent location type name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "temporaryLocation": {
+      "description": "Temporary item location is the temporarily location, shelving location, or holding which is a physical place where items are stored, or an Online location. The location is defined by Institutions, Campuses, libraries, and locations. Permanent location can be assigned at the holding level, and be overridden at the item level if needed",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Temporary location Id, refers to a location type reference record",
+          "type": "string"
+        },
+        "name": {
+          "description": "Temporary location name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "effectiveLocation": {
+      "type": "object",
+      "description": "The effective location is used by FOLIO and other integrated systems to know the current home location for the item (read only, derived from locations on HoldingsRecord and Item)",
+      "readonly": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "readonly": true
+        },
+        "name": {
+          "description": "Effective location name",
+          "type": "string",
+          "readonly": true
+        }
+      }
+    },
+    "electronicAccess": {
+      "description": "Whether an item is available electronically",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Uniform Resource Identifier (URI) is a string of characters designed for unambiguous identification of resources"
+          },
+          "linkText": {
+            "type": "string",
+            "description": "Link text is used for display in place of the URL"
+          },
+          "materialsSpecification": {
+            "type": "string",
+            "description": "Materials specified is used to specify to what portion or aspect of the resource the electronic location and access information applies (e.g. a portion or subset of the item is electronic, or a related electronic resource is being linked to the record)"
+          },
+          "publicNote": {
+            "type": "string",
+            "description": "URL public note to be displayed in the discovery"
+          },
+          "relationshipId": {
+            "type": "string",
+            "description": "Relationship Id, refers to a Relationship type reference record. Relationship between the electronic resource at the location identified and the item described in the record as a whole. (E.g. values from MARC 21, tag field 856 2nd indicator, where the values are: No information provided, Resource, Version of resource, Related resource, No display constant generate"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "uri"
+        ]
+      }
+    },
+    "statisticalCodeIds": {
+      "type": "array",
+      "description": "Statistical code Id, refers to a Statistical code reference record",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "purchaseOrderLineIdentifier": {
+      "type": "string",
+      "description": "ID referencing a remote purchase order object related to this item"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    },
+    "tags": {
+      "description": "arbitrary tags associated with this item",
+      "id": "tags",
+      "type": "object",
+      "$ref": "raml-util/schemas/tags.schema"
+    },
+    "lastCheckIn": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about when an item was last checked in",
+      "properties": {
+        "dateTime": {
+          "type": "string",
+          "description": "Date and time of the last check in of the item.",
+          "format": "date-time",
+          "readonly": true
+        },
+        "servicePointId": {
+          "type": "string",
+          "description": "Service point ID being used by a staff member when item was scanned in Check in app.",
+          "$ref": "uuid.json",
+          "readonly": true
+        },
+        "staffMemberId": {
+          "type": "string",
+          "description": "ID a staff member who scanned the item",
+          "$ref": "uuid.json",
+          "readonly": true
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "materialType",
+    "permanentLoanType",
+    "status"
+  ]
+}

--- a/ramls/items.json
+++ b/ramls/items.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of item records",
+  "type": "object",
+  "properties": {
+    "items": {
+      "description": "List of item records",
+      "id": "items",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "item.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items",
+    "totalRecords"
+  ]
+}

--- a/ramls/uuid.json
+++ b/ramls/uuid.json
@@ -1,0 +1,5 @@
+{
+  "description": "A universally unique identifier (UUID), this is a 128-bit number used to identify a record and is shown in hex with dashes, for example 6312d172-f0cf-40f6-b27d-9fa8feaf332f; the UUID version must be from 1-5; see https://dev.folio.org/guides/uuids/",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+}

--- a/src/main/java/org/folio/rest/client/InventoryClient.java
+++ b/src/main/java/org/folio/rest/client/InventoryClient.java
@@ -1,0 +1,109 @@
+package org.folio.rest.client;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.folio.rest.jaxrs.model.HoldingsRecords;
+import org.folio.rest.jaxrs.model.Items;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+
+public class InventoryClient extends OkapiClient {
+
+  private static final String ITEMS_LIMIT = "1000";
+  private static final String HOLDINGS_LIMIT = "1000";
+
+  public InventoryClient(WebClient webClient, Map<String, String> okapiHeaders) {
+    super(webClient, okapiHeaders);
+  }
+
+  public Future<Items> getItemsById(List<String> itemIds) {
+    if (itemIds.size() == 0) {
+      return Future.succeededFuture(new Items()
+        .withItems(new ArrayList<>())
+        .withTotalRecords(0));
+    }
+
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    HttpRequest<Buffer> request = okapiGetAbs("/inventory/items");
+    if (!itemIds.isEmpty()) {
+      request.addQueryParam("query", String.format("(id==(%s))",
+        itemIds.stream()
+          .map(id -> String.format("\"%s\"", id))
+          .collect(Collectors.joining(" or "))))
+      .addQueryParam("limit", ITEMS_LIMIT);
+    }
+    request.send(promise);
+
+    return promise.future().compose(response -> {
+      if (response.statusCode() != 200) {
+        return failedFuture("Failed to get items by IDs. Response status code: "
+          + response.statusCode());
+      }
+      else {
+        try {
+          Items items = objectMapper.readValue(response.bodyAsString(), Items.class);
+          return succeededFuture(items);
+        }
+        catch (IOException ioException) {
+          return failedFuture("Failed to parse request. Response body: "
+            + response.bodyAsString());
+        }
+      }
+    });
+  }
+
+  public Future<HoldingsRecords> getHoldingsById(List<String> holdingIds) {
+    if (holdingIds.size() == 0) {
+      return Future.succeededFuture(new HoldingsRecords()
+        .withHoldingsRecords(new ArrayList<>())
+        .withTotalRecords(0));
+    }
+
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    HttpRequest<Buffer> request = okapiGetAbs("/holdings-storage/holdings");
+    if (!holdingIds.isEmpty()) {
+      request.addQueryParam("query", String.format("(id==(%s))",
+        holdingIds.stream()
+          .map(id -> String.format("\"%s\"", id))
+          .collect(Collectors.joining(" or "))))
+        .addQueryParam("limit", HOLDINGS_LIMIT);
+    }
+    request.putHeader(ACCEPT, APPLICATION_JSON);
+    request.send(promise);
+
+    return promise.future().compose(response -> {
+      if (response.statusCode() != 200) {
+        return failedFuture("Failed to get holdings by IDs. Response status code: "
+          + response.statusCode());
+      }
+      else {
+        try {
+          HoldingsRecords holdingsRecords = objectMapper.readValue(response.bodyAsString(),
+            HoldingsRecords.class);
+          return succeededFuture(holdingsRecords);
+        }
+        catch (IOException ioException) {
+          return failedFuture("Failed to parse request. Response body: "
+            + response.bodyAsString());
+        }
+      }
+    });
+  }
+
+}

--- a/src/main/java/org/folio/rest/client/OkapiClient.java
+++ b/src/main/java/org/folio/rest/client/OkapiClient.java
@@ -1,0 +1,46 @@
+package org.folio.rest.client;
+
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+
+public class OkapiClient {
+  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WebClient webClient;
+  private String okapiUrl;
+  protected String tenant;
+  private String token;
+
+  OkapiClient(WebClient webClient, Map<String, String> okapiHeaders) {
+    this.webClient = webClient;
+    okapiUrl = okapiHeaders.get(OKAPI_URL_HEADER);
+    tenant = okapiHeaders.get(OKAPI_HEADER_TENANT);
+    token = okapiHeaders.get(OKAPI_HEADER_TOKEN);
+  }
+
+  HttpRequest<Buffer> okapiGetAbs(String path) {
+    return webClient.getAbs(okapiUrl + path)
+      .putHeader(OKAPI_HEADER_TENANT, tenant)
+      .putHeader(OKAPI_URL_HEADER, okapiUrl)
+      .putHeader(OKAPI_HEADER_TOKEN, token);
+  }
+
+  HttpRequest<Buffer> okapiPostAbs(String path) {
+    return webClient.postAbs(okapiUrl + path)
+      .putHeader(ACCEPT, APPLICATION_JSON)
+      .putHeader(OKAPI_HEADER_TENANT, tenant)
+      .putHeader(OKAPI_URL_HEADER, okapiUrl)
+      .putHeader(OKAPI_HEADER_TOKEN, token);
+  }
+}

--- a/src/main/java/org/folio/rest/client/PatronNoticeClient.java
+++ b/src/main/java/org/folio/rest/client/PatronNoticeClient.java
@@ -2,10 +2,6 @@ package org.folio.rest.client;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
-import static javax.ws.rs.core.HttpHeaders.ACCEPT;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 
 import java.util.Map;
 
@@ -17,30 +13,15 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
-public class PatronNoticeClient {
-
-  private static final String OKAPI_URL_HEADER = "x-okapi-url";
-
-  private WebClient webClient;
-  private String okapiUrl;
-  private String tenant;
-  private String token;
+public class PatronNoticeClient extends OkapiClient {
 
   public PatronNoticeClient(WebClient webClient, Map<String, String> okapiHeaders) {
-    this.webClient = webClient;
-    okapiUrl = okapiHeaders.get(OKAPI_URL_HEADER);
-    tenant = okapiHeaders.get(OKAPI_HEADER_TENANT);
-    token = okapiHeaders.get(OKAPI_HEADER_TOKEN);
+    super(webClient, okapiHeaders);
   }
 
   public Future<Void> postPatronNotice(PatronNotice notice) {
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
-    webClient.postAbs(okapiUrl + "/patron-notice")
-      .putHeader(ACCEPT, APPLICATION_JSON)
-      .putHeader(OKAPI_HEADER_TENANT, tenant)
-      .putHeader(OKAPI_URL_HEADER, okapiUrl)
-      .putHeader(OKAPI_HEADER_TOKEN, token)
-        .sendJson(notice, promise);
+    okapiPostAbs("/patron-notice").sendJson(notice, promise);
 
     return promise.future().compose(response -> response.statusCode() == 200 ?
       succeededFuture() :

--- a/src/main/java/org/folio/rest/impl/AccountsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AccountsAPI.java
@@ -220,10 +220,10 @@ public class AccountsAPI implements Accounts {
                                                                 MessageConsts.InternalServerError))));
                                     } else {
                                           setAdditionalFields(vertxContext.owner(), okapiHeaders, accountList)
-                                            .setHandler(accountsResult -> {
-                                              asyncResultHandler.handle(Future.succeededFuture(
-                                                GetAccountsByAccountIdResponse.respond200WithApplicationJson(accountList.get(0))));
-                                            });
+                                            .setHandler(accountsResult -> asyncResultHandler.handle(
+                                              Future.succeededFuture(
+                                                GetAccountsByAccountIdResponse.respond200WithApplicationJson(
+                                                  accountList.get(0)))));
                                     }
                                 }
                             });

--- a/src/main/java/org/folio/rest/impl/AccountsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AccountsAPI.java
@@ -310,8 +310,8 @@ public class AccountsAPI implements Accounts {
     }
 
     private class AdditionalFieldsContext {
-      Items items;
-      HoldingsRecords holdings;
+      final Items items;
+      final HoldingsRecords holdings;
 
       public AdditionalFieldsContext(Items items, HoldingsRecords holdings) {
         this.items = items;

--- a/src/main/java/org/folio/rest/impl/AccountsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AccountsAPI.java
@@ -3,15 +3,22 @@ package org.folio.rest.impl;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.client.InventoryClient;
 import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.AccountdataCollection;
 import org.folio.rest.jaxrs.model.AccountsGetOrder;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.HoldingsRecords;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Items;
 import org.folio.rest.jaxrs.resource.Accounts;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -31,8 +38,10 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.client.WebClient;
 
 public class AccountsAPI implements Accounts {
 
@@ -47,7 +56,51 @@ public class AccountsAPI implements Accounts {
         return new CQLWrapper(cql2pgJson, query).setLimit(new Limit(limit)).setOffset(new Offset(offset));
     }
 
-    @Validate
+  private Future<Void> setAdditionalFields(Vertx vertx, Map<String, String> okapiHeaders,
+    List<Account> accounts) {
+
+    if (accounts == null) {
+      return Future.succeededFuture(null);
+    }
+
+    InventoryClient inventoryClient = new InventoryClient(WebClient.create(vertx), okapiHeaders);
+
+    List<String> itemIds = accounts.stream()
+      .map(Account::getItemId)
+      .collect(Collectors.toList());
+
+    return Future.succeededFuture(new AdditionalFieldsContext(null, null))
+      .compose(ctx -> inventoryClient.getItemsById(itemIds)
+          .map(ctx::withItems))
+      .compose(ctx -> inventoryClient.getHoldingsById(ctx.items.getItems().stream()
+        .map(Item::getHoldingsRecordId)
+        .collect(Collectors.toList()))
+        .map(ctx::withHoldings))
+      .compose(ctx -> {
+        accounts.forEach(account -> {
+          Optional<Item> item = ctx.items.getItems().stream()
+            .filter(i -> account.getItemId().equals(i.getId()))
+            .findAny();
+
+          Optional<HoldingsRecord> holding = Optional.empty();
+          if (item.isPresent() && item.get().getHoldingsRecordId() != null) {
+            holding = ctx.holdings.getHoldingsRecords().stream()
+              .filter(h -> item.get().getHoldingsRecordId().equals(h.getId()))
+              .findAny();
+          }
+
+          String holdingRecordsId = item.map(Item::getHoldingsRecordId).orElse("");
+          String instanceId = holding.map(HoldingsRecord::getInstanceId).orElse("");
+
+          account.setHoldingsRecordId(holdingRecordsId);
+          account.setInstanceId(instanceId);
+        });
+
+        return Future.succeededFuture(null);
+      });
+  }
+
+  @Validate
     @Override
     public void getAccounts(String query, String orderBy, AccountsGetOrder order, int offset, int limit, List<String> facets, String lang,
             Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
@@ -66,13 +119,17 @@ public class AccountsAPI implements Accounts {
                             true, false, facetList, reply -> {
                                 try {
                                     if (reply.succeeded()) {
-                                        AccountdataCollection accountCollection = new AccountdataCollection();
-                                        List<Account> accounts = reply.result().getResults();
-                                        accountCollection.setAccounts(accounts);
-                                        accountCollection.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
-                                        accountCollection.setResultInfo(reply.result().getResultInfo());
-                                        asyncResultHandler.handle(Future.succeededFuture(
-                                                GetAccountsResponse.respond200WithApplicationJson(accountCollection)));
+                                      List<Account> accounts = reply.result().getResults();
+
+                                      setAdditionalFields(vertxContext.owner(), okapiHeaders, accounts)
+                                        .setHandler(accountsResult -> {
+                                          AccountdataCollection accountCollection = new AccountdataCollection();
+                                          accountCollection.setAccounts(accounts);
+                                          accountCollection.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
+                                          accountCollection.setResultInfo(reply.result().getResultInfo());
+                                          asyncResultHandler.handle(Future.succeededFuture(
+                                            GetAccountsResponse.respond200WithApplicationJson(accountCollection)));
+                                        });
                                     } else {
                                         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                                                 GetAccountsResponse.respond500WithTextPlain(
@@ -162,8 +219,11 @@ public class AccountsAPI implements Accounts {
                                                         messages.getMessage(lang,
                                                                 MessageConsts.InternalServerError))));
                                     } else {
-                                        asyncResultHandler.handle(Future.succeededFuture(
+                                          setAdditionalFields(vertxContext.owner(), okapiHeaders, accountList)
+                                            .setHandler(accountsResult -> {
+                                              asyncResultHandler.handle(Future.succeededFuture(
                                                 GetAccountsByAccountIdResponse.respond200WithApplicationJson(accountList.get(0))));
+                                            });
                                     }
                                 }
                             });
@@ -247,5 +307,23 @@ public class AccountsAPI implements Accounts {
 
       PgUtil.put(ACCOUNTS_TABLE, entity, accountId, okapiHeaders, vertxContext,
         PutAccountsByAccountIdResponse.class, asyncResultHandler);
+    }
+
+    private class AdditionalFieldsContext {
+      Items items;
+      HoldingsRecords holdings;
+
+      public AdditionalFieldsContext(Items items, HoldingsRecords holdings) {
+        this.items = items;
+        this.holdings = holdings;
+      }
+
+      AdditionalFieldsContext withItems(Items items) {
+        return new AdditionalFieldsContext(items, this.holdings);
+      }
+
+      AdditionalFieldsContext withHoldings(HoldingsRecords holdings) {
+        return new AdditionalFieldsContext(this.items, holdings);
+      }
     }
 }

--- a/src/test/java/org/folio/rest/impl/AccountsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AccountsAPITest.java
@@ -1,0 +1,199 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
+import java.util.UUID;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.UpdateResult;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class AccountsAPITest {
+  private static final Logger logger = LoggerFactory.getLogger(FeeFinesAPITest.class);
+
+  private static final String OKAPI_URL = "x-okapi-url";
+  private static final String HTTP_PORT = "http.port";
+  private static final String REST_PATH = "/accounts";
+  private static final String OKAPI_TOKEN = "test_token";
+  private static final String OKAPI_URL_TEMPLATE = "http://localhost:%s";
+  private static final String ACCOUNTS_TABLE = "accounts";
+  private static final String ITEM_ID = "43ec57e3-3974-4d05-a2c2-95126e087b72";
+
+  private static Vertx vertx;
+  private static int port;
+  private static String okapiTenant = "test_tenant";
+
+  private String okapiUrl;
+
+  @Rule
+  public WireMockRule userMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  @BeforeClass
+  public static void setUpClass(final TestContext context) throws Exception {
+    Async async = context.async();
+    vertx = Vertx.vertx();
+    port = NetworkUtils.nextFreePort();
+
+    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+
+    TenantClient tenantClient =
+      new TenantClient(String.format(OKAPI_URL_TEMPLATE, port), okapiTenant, OKAPI_TOKEN);
+    DeploymentOptions restDeploymentOptions = new DeploymentOptions()
+      .setConfig(new JsonObject().put(HTTP_PORT, port));
+    TenantAttributes attributes = new TenantAttributes()
+      .withModuleTo(String.format("mod-feesfines-%s", PomReader.INSTANCE.getVersion()));
+
+    vertx.deployVerticle(RestVerticle.class.getName(), restDeploymentOptions,
+      res -> {
+        try {
+          tenantClient.postTenant(attributes, res2 -> async.complete()
+          );
+        } catch (Exception e) {
+          logger.error(e.getMessage());
+        }
+      });
+  }
+
+  @Before
+  public void setUp(TestContext context) {
+    Async async = context.async();
+    PostgresClient client = PostgresClient.getInstance(vertx, okapiTenant);
+
+    userMockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/inventory/items.*"))
+      .willReturn(aResponse().withBodyFile("items.json")));
+
+    userMockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/holdings-storage/holdings.*"))
+      .willReturn(aResponse().withBodyFile("holdings.json")));
+
+    client.delete(ACCOUNTS_TABLE, new Criterion(), result -> processEvent(context, result, async));
+    async.complete();
+  }
+
+  @AfterClass
+  public static void tearDownClass(final TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void canGetAccounts() {
+    post(createAccountJson(randomId()))
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .contentType(ContentType.JSON);
+
+    get("/accounts")
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .contentType(ContentType.JSON);
+  }
+
+  @Test
+  public void canGetAccount() {
+    String accountId = randomId();
+
+    post(createAccountJson(accountId))
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .contentType(ContentType.JSON);
+
+    get(String.format("/accounts/%s", accountId))
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .contentType(ContentType.JSON);
+  }
+
+  private String createAccountJson(String accountID) {
+    return new JsonObject()
+      .put("id", accountID)
+      .put("userId", randomId())
+      .put("feeFineId", randomId())
+      .put("materialTypeId", randomId())
+      .put("ownerId", randomId())
+      .put("itemId", ITEM_ID)
+      .encodePrettily();
+  }
+
+  private Response get(String path) {
+    return getRequestSpecification()
+      .when()
+      .get(REST_PATH);
+  }
+
+  private Response post(String body) {
+    return getRequestSpecification()
+      .body(body)
+      .when()
+      .post(REST_PATH);
+  }
+
+  private RequestSpecification getRequestSpecification() {
+    if (okapiUrl == null) {
+      okapiUrl = String.format(OKAPI_URL_TEMPLATE, userMockServer.port());
+    }
+
+    return RestAssured.given()
+      .port(port)
+      .contentType(MediaType.APPLICATION_JSON)
+      .header(new Header(OKAPI_HEADER_TENANT, okapiTenant))
+      .header(new Header(OKAPI_URL, okapiUrl))
+      .header(new Header(OKAPI_HEADER_TOKEN, OKAPI_TOKEN));
+  }
+
+  private String randomId() {
+    return UUID.randomUUID().toString();
+  }
+
+  private void processEvent(TestContext context, AsyncResult<UpdateResult> event, Async async) {
+    if (event.failed()) {
+      logger.error(event.cause());
+      context.fail(event.cause());
+    } else {
+      async.countDown();
+    }
+  }
+}

--- a/src/test/resources/__files/holdings.json
+++ b/src/test/resources/__files/holdings.json
@@ -1,0 +1,25 @@
+{
+  "holdingsRecords": [
+    {
+      "id": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61",
+      "instanceId": "cd28da0f-a3e4-465c-82f1-acade4e8e170",
+      "permanentLocationId": "d9cd0bed-1b49-4b5e-a7bd-064b8d177231",
+      "holdingsStatements": [
+        {
+          "statement": "Line 1",
+          "note": "Note to line 1"
+        },
+        {
+          "statement": "Line 2",
+          "note": "Note to line2"
+        }
+      ],
+      "tags" : {
+        "tagList" : [
+          "important"
+        ]
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/__files/items.json
+++ b/src/test/resources/__files/items.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "id": "43ec57e3-3974-4d05-a2c2-95126e087b72",
+      "title": "Nod",
+      "barcode": "456743454532",
+      "status": {
+        "name": "Available"
+      },
+      "materialType": {
+        "id": "fcf3d3dc-b27f-4ce4-a530-542ea53cacb5",
+        "name": "Book"
+      },
+      "permanentLocation": {
+        "id": "d9cd0bed-1b49-4b5e-a7bd-064b8d177231",
+        "name": "Main Library"
+      },
+      "permanentLoanType": {
+        "id": "11477028-d9e6-44d2-9364-5c6f51053f51",
+        "name": "Reading Room"
+      },
+      "tags": {
+        "tagList": [
+          "important"
+        ]
+      },
+      "holdingsRecordId": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61"
+    }
+  ],
+  "totalRecords": 1
+}


### PR DESCRIPTION
Adding two fields - holdingsRecordId and instanceId. The are populated on the fly for `/accounts` and `/account/{id}` requests.

This resolves MODFEE-48 which in turn helps to resolve UIU-1553 bug.