### PR TITLE
MODFEE-50 Remove readonly fields validation

### DIFF
--- a/ramls/accountdata.json
+++ b/ramls/accountdata.json
@@ -135,14 +135,12 @@
     "holdingsRecordId": {
       "description": "Item field: item.holdingsRecordId",
       "type": "string",
-      "readonly": true,
-      "$ref": "uuid.json"
+      "readonly": true
     },
     "instanceId": {
       "description": "Holdings record field: holdingsRecord.instanceId",
       "type": "string",
-      "readonly": true,
-      "$ref": "uuid.json"
+      "readonly": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Resolves [MODFEE-50](https://issues.folio.org/browse/MODFEE-50).

FE is trying to update these fields with `PUT /accounts/{id}` request, passing empty
strings. Though these fields are readonly and should be ignored by RMB, it still validates them which causes validation failures.