### PR TITLE
Update pubsub client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>1.1.5</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
Updating to the latest pubsub client seems to resolve https://issues.folio.org/browse/MODFEE-69. So likely the issue is related to https://issues.folio.org/browse/MODPUBSUB-95 and that was fixed in mod-pubsub 1.2.0 release.