### PR TITLE
[MODFEE-72] Add token `feeCharge.additionalInfo`

### DIFF
--- a/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
+++ b/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
@@ -153,6 +153,7 @@ public class PatronNoticeBuilder {
 
   private static JsonObject buildFeeChargeContext(FeeFineNoticeContext ctx) {
     final Account account = ctx.getAccount();
+    final Feefineaction action = ctx.getFeefineaction();
     final JsonObject feeChargeContext = new JsonObject();
 
     if (account == null) {
@@ -176,6 +177,10 @@ public class PatronNoticeBuilder {
       feeChargeContext
         .put("chargeDate", chargeDate)
         .put("chargeDateTime", chargeDate);
+    }
+
+    if (action != null) {
+      feeChargeContext.put("additionalInfo", getCommentsFromFeeFineAction(action));
     }
 
     return feeChargeContext;

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -82,6 +82,7 @@ public class FeeFineActionsAPITest extends ApiTests {
 
   private static final String PRIMARY_CONTRIBUTOR_NAME = "Primary contributor";
   private static final String NON_PRIMARY_CONTRIBUTOR_NAME = "Non-primary contributor";
+  private static final String COMMENT_FOR_PATRON = "patron comment";
 
   private static final NumberFormat CURRENCY_FORMATTER = new DecimalFormat("#0.00");
 
@@ -166,14 +167,15 @@ public class FeeFineActionsAPITest extends ApiTests {
           .put("amount", CURRENCY_FORMATTER.format(account.getAmount()))
           .put("remainingAmount", CURRENCY_FORMATTER.format(account.getRemaining()))
           .put("chargeDate", accountCreationDate)
-          .put("chargeDateTime", accountCreationDate))
+          .put("chargeDateTime", accountCreationDate)
+          .put("additionalInfo", COMMENT_FOR_PATRON))
         .put("feeAction", new JsonObject()
           .put("type", action.getTypeAction())
           .put("actionDate", dateToString(action.getDateAction()))
           .put("actionDateTime", dateToString(action.getDateAction()))
           .put("amount", CURRENCY_FORMATTER.format(action.getAmountAction()))
           .put("remainingAmount", CURRENCY_FORMATTER.format(action.getBalance()))
-          .put("additionalInfo", "patron comment")
+          .put("additionalInfo", COMMENT_FOR_PATRON)
         )
       );
 
@@ -318,7 +320,7 @@ public class FeeFineActionsAPITest extends ApiTests {
       .withDateAction(new Date())
       .withAmountAction(4.45)
       .withBalance(8.55)
-      .withComments("STAFF : staff comment \n PATRON : patron comment");
+      .withComments("STAFF : staff comment \n PATRON : " + COMMENT_FOR_PATRON);
   }
 
   private static Feefine createFeeFine(Owner owner) {

--- a/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
+++ b/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
@@ -47,6 +47,7 @@ import io.vertx.core.json.JsonObject;
 
 public class PatronNoticeBuilderTest {
   private static final String NAME = "name";
+  private static final String COMMENT_FOR_PATRON = "patron comment";
   private static final NumberFormat CURRENCY_FORMATTER = new DecimalFormat("#0.00");
 
   @Test
@@ -133,6 +134,8 @@ public class PatronNoticeBuilderTest {
     assertEquals(CURRENCY_FORMATTER.format(account.getRemaining()), chargeContext.getString("remainingAmount"));
     assertEquals(dateToString(account.getMetadata().getCreatedDate()), chargeContext.getString("chargeDate"));
     assertEquals(dateToString(account.getMetadata().getCreatedDate()), chargeContext.getString("chargeDateTime"));
+    assertEquals(COMMENT_FOR_PATRON, chargeContext.getString("additionalInfo"));
+
 
     final JsonObject actionContext = (JsonObject) context.getAdditionalProperties().get("feeAction");
 
@@ -141,7 +144,7 @@ public class PatronNoticeBuilderTest {
     assertEquals(dateToString(action.getDateAction()), actionContext.getString("actionDateTime"));
     assertEquals(CURRENCY_FORMATTER.format(action.getAmountAction()), actionContext.getString("amount"));
     assertEquals(CURRENCY_FORMATTER.format(action.getBalance()), actionContext.getString("remainingAmount"));
-    assertEquals("patron comment", actionContext.getString("additionalInfo"));
+    assertEquals(COMMENT_FOR_PATRON, actionContext.getString("additionalInfo"));
   }
 
   @Test
@@ -237,7 +240,7 @@ public class PatronNoticeBuilderTest {
       .withDateAction(new Date())
       .withAmountAction(4.45)
       .withBalance(8.55)
-      .withComments("STAFF : staff comment \n PATRON : patron comment");
+      .withComments("STAFF : staff comment \n PATRON : " + COMMENT_FOR_PATRON);
   }
 
   private static Feefine createFeeFine() {


### PR DESCRIPTION
**Purpose**: add missing token `feeCharge.additionalInfo`.

Resolves [MODFEE-72](https://issues.folio.org/browse/MODFEE-72).