### PR TITLE
MODFEE-139 - Fees/fines records in Circulation log do not contain item details

### DIFF
--- a/src/main/java/org/folio/rest/domain/logs/LogEventPayloadHelper.java
+++ b/src/main/java/org/folio/rest/domain/logs/LogEventPayloadHelper.java
@@ -106,6 +106,7 @@ public class LogEventPayloadHelper {
       write(json, FEE_FINE_ID.value(), acc.getFeeFineId());
       write(json, FEE_FINE_OWNER.value(), acc.getFeeFineOwner());
       write(json, ITEM_BARCODE.value(), acc.getBarcode());
+      write(json, ITEM_ID.value(), acc.getItemId());
       write(json, LOAN_ID.value(), acc.getLoanId());
     });
 

--- a/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
@@ -351,6 +351,7 @@ public class AccountsBulkPayWaiveTransferAPITests extends ApiTests {
       .withId(accountId)
       .withOwnerId(randomId())
       .withUserId(USER_ID)
+      .withBarcode("barcode")
       .withItemId(randomId())
       .withLoanId(randomId())
       .withMaterialTypeId(randomId())

--- a/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
@@ -37,7 +37,6 @@ import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
-import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.utils.ResourceClient;
 import org.folio.test.support.ApiTests;
 import org.folio.util.pubsub.PubSubClientUtils;
@@ -315,6 +314,7 @@ public class AccountsPayWaiveTransferAPITests extends ApiTests {
       .withId(ACCOUNT_ID)
       .withOwnerId(randomId())
       .withUserId(randomId())
+      .withBarcode("barcode")
       .withItemId(randomId())
       .withLoanId(randomId())
       .withMaterialTypeId(randomId())

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -223,6 +223,7 @@ public class FeeFineActionsAPITest extends ApiTests {
     expectedFeeFineLogContext = new JsonObject()
       .put("userId", user.getId())
       .put("itemBarcode", account.getBarcode())
+      .put("itemId", account.getItemId())
       .put("action", action.getTypeAction())
       .put("feeFineId", account.getFeeFineId())
       .put("feeFineOwner", account.getFeeFineOwner())

--- a/src/test/java/org/folio/test/support/matcher/LogEventMatcher.java
+++ b/src/test/java/org/folio/test/support/matcher/LogEventMatcher.java
@@ -10,6 +10,8 @@ import static org.folio.rest.domain.logs.LogEventPayloadField.COMMENTS;
 import static org.folio.rest.domain.logs.LogEventPayloadField.DATE;
 import static org.folio.rest.domain.logs.LogEventPayloadField.FEE_FINE_ID;
 import static org.folio.rest.domain.logs.LogEventPayloadField.FEE_FINE_OWNER;
+import static org.folio.rest.domain.logs.LogEventPayloadField.ITEM_BARCODE;
+import static org.folio.rest.domain.logs.LogEventPayloadField.ITEM_ID;
 import static org.folio.rest.domain.logs.LogEventPayloadField.LOAN_ID;
 import static org.folio.rest.domain.logs.LogEventPayloadField.PAYMENT_METHOD;
 import static org.folio.rest.domain.logs.LogEventPayloadField.SERVICE_POINT_ID;
@@ -37,24 +39,26 @@ public class LogEventMatcher {
 
   public static Matcher<String> feeFineActionLogEventPayload(Account account, DefaultBulkActionRequest request,
     String action, double amount, double balance) {
-    return feeFineActionLogEventPayload(account.getUserId(), action, request.getServicePointId(),
-      request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(), account.getLoanId(),
-      amount, balance, request.getPaymentMethod(), request.getComments());
+    return feeFineActionLogEventPayload(account.getUserId(), account.getBarcode(), account.getItemId(),
+      action, request.getServicePointId(), request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(),
+      account.getLoanId(), amount, balance, request.getPaymentMethod(), request.getComments());
   }
 
   public static Matcher<String> feeFineActionLogEventPayload(Account account, DefaultActionRequest request,
     String action, double amount, double balance) {
-    return feeFineActionLogEventPayload(account.getUserId(), action, request.getServicePointId(),
-      request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(), account.getLoanId(),
-      amount, balance, request.getPaymentMethod(), request.getComments());
+    return feeFineActionLogEventPayload(account.getUserId(), account.getBarcode(), account.getItemId(),
+      action, request.getServicePointId(), request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(),
+      account.getLoanId(), amount, balance, request.getPaymentMethod(), request.getComments());
   }
 
-  public static Matcher<String> feeFineActionLogEventPayload(String userId, String action, String servicePointId,
-    String source, String feeFineId, String feeFineOwner, String loanId, double amount, double balance,
-    String paymentMethod, String comments) {
+  public static Matcher<String> feeFineActionLogEventPayload(String userId, String itemBarcode, String itemId,
+    String action, String servicePointId, String source, String feeFineId,
+    String feeFineOwner, String loanId, double amount, double balance, String paymentMethod, String comments) {
 
     return allOf(Arrays.asList(
       hasJsonPath(USER_ID.value(), is(userId)),
+      hasJsonPath(ITEM_BARCODE.value(), is(itemBarcode)),
+      hasJsonPath(ITEM_ID.value(), is(itemId)),
       hasJsonPath(ACTION.value(), is(action)),
       hasJsonPath(DATE.value(), notNullValue(Date.class)),
       hasJsonPath(SERVICE_POINT_ID.value(), is(servicePointId)),
@@ -69,22 +73,23 @@ public class LogEventMatcher {
   }
 
   public static Matcher<String> cancelledActionLogEventPayload(Account account, CancelActionRequest request) {
-    return cancelledActionLogEventPayload(account.getUserId(), request.getServicePointId(),
+    return cancelledActionLogEventPayload(account.getUserId(), account.getItemId(), request.getServicePointId(),
       request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(), account.getLoanId(),
       account.getAmount(), request.getComments());
   }
 
   public static Matcher<String> cancelledActionLogEventPayload(Account account, CancelBulkActionRequest request) {
-    return cancelledActionLogEventPayload(account.getUserId(), request.getServicePointId(),
+    return cancelledActionLogEventPayload(account.getUserId(), account.getItemId(), request.getServicePointId(),
       request.getUserName(), account.getFeeFineId(), account.getFeeFineOwner(), account.getLoanId(),
       account.getAmount(), request.getComments());
   }
 
-  public static Matcher<String> cancelledActionLogEventPayload(String userId, String servicePointId, String source,
+  public static Matcher<String> cancelledActionLogEventPayload(String userId, String itemId, String servicePointId, String source,
     String feeFineId, String feeFineOwner, String loanId, double amount, String comments) {
 
     return allOf(Arrays.asList(
       hasJsonPath(USER_ID.value(), is(userId)),
+      hasJsonPath(ITEM_ID.value(), is(itemId)),
       hasJsonPath(ACTION.value(), is(Action.CANCEL.getFullResult())),
       hasJsonPath(DATE.value(), notNullValue(Date.class)),
       hasJsonPath(SERVICE_POINT_ID.value(), is(servicePointId)),


### PR DESCRIPTION
[MODFEE-139](https://issues.folio.org/browse/MODFEE-139) - Fees/fines records in Circulation log do not contain item details
This PR fixes an issue by adding item info into log record payload