### PR TITLE
MODFEE-137: Add ability to provide custom cancellation reason for an account.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -54,7 +54,7 @@
   "provides":[
     {
       "id":"feesfines",
-      "version":"16.0",
+      "version":"16.1",
       "handlers":[
         {
           "methods":[

--- a/ramls/accounts.raml
+++ b/ramls/accounts.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Accounts
-version: v1.1
+version: v16.1
 baseUri: http://github.com/org/folio/mod-feesfines
 
 documentation:

--- a/ramls/accounts.raml
+++ b/ramls/accounts.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Accounts
-version: v1
+version: v1.1
 baseUri: http://github.com/org/folio/mod-feesfines
 
 documentation:

--- a/ramls/actions/cancelActionRequest.json
+++ b/ramls/actions/cancelActionRequest.json
@@ -19,6 +19,11 @@
     "userName": {
       "type": "string",
       "description": "Name of the user that was logged in when the action was performed"
+    },
+    "cancellationReason": {
+      "type": "string",
+      "description": "Reason for cancellation",
+      "default": "Cancelled as error"
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/rest/domain/ActionRequest.java
+++ b/src/main/java/org/folio/rest/domain/ActionRequest.java
@@ -17,10 +17,11 @@ public class ActionRequest {
   private final String userName;
   private final String paymentMethod;
   private final boolean notifyPatron;
+  private final String reasonForAction;
 
   public ActionRequest(List<String> accountIds, String amount, String comments,
     String transactionInfo, String servicePointId, String userName, String paymentMethod,
-    boolean notifyPatron) {
+    boolean notifyPatron, String reasonForAction) {
 
     this.accountIds = accountIds;
     this.amount = amount;
@@ -30,6 +31,7 @@ public class ActionRequest {
     this.userName = userName;
     this.paymentMethod = paymentMethod;
     this.notifyPatron = notifyPatron;
+    this.reasonForAction = reasonForAction;
   }
 
   public List<String> getAccountIds() {
@@ -64,6 +66,10 @@ public class ActionRequest {
     return notifyPatron;
   }
 
+  public String getReasonForAction() {
+    return reasonForAction;
+  }
+
   public static ActionRequest from(DefaultActionRequest request, String accountId) {
     return new ActionRequest(
       Collections.singletonList(accountId),
@@ -73,7 +79,8 @@ public class ActionRequest {
       request.getServicePointId(),
       request.getUserName(),
       request.getPaymentMethod(),
-      request.getNotifyPatron());
+      request.getNotifyPatron(),
+      null);
   }
 
   public static ActionRequest from(DefaultBulkActionRequest request) {
@@ -85,7 +92,8 @@ public class ActionRequest {
       request.getServicePointId(),
       request.getUserName(),
       request.getPaymentMethod(),
-      request.getNotifyPatron());
+      request.getNotifyPatron(),
+      null);
   }
 
   public static ActionRequest from(CancelActionRequest request, String accountId) {
@@ -97,7 +105,8 @@ public class ActionRequest {
       request.getServicePointId(),
       request.getUserName(),
       null,
-      request.getNotifyPatron());
+      request.getNotifyPatron(),
+      request.getCancellationReason());
   }
 
   public static ActionRequest from(CancelBulkActionRequest request) {
@@ -109,6 +118,7 @@ public class ActionRequest {
       request.getServicePointId(),
       request.getUserName(),
       null,
-      request.getNotifyPatron());
+      request.getNotifyPatron(),
+      null);
   }
 }

--- a/src/main/java/org/folio/rest/service/action/CancelActionService.java
+++ b/src/main/java/org/folio/rest/service/action/CancelActionService.java
@@ -36,7 +36,8 @@ public class CancelActionService extends ActionService {
     ActionRequest request) {
 
     final MonetaryValue remainingAmountAfterAction = new MonetaryValue(0.0);
-    String actionType = action.getFullResult();
+    final String reasonForAction = request.getReasonForAction() != null
+      ? request.getReasonForAction() : action.getFullResult();
 
     final Feefineaction feeFineAction = new Feefineaction()
       .withAmountAction(account.getAmount())
@@ -46,11 +47,11 @@ public class CancelActionService extends ActionService {
       .withAccountId(account.getId())
       .withUserId(account.getUserId())
       .withBalance(remainingAmountAfterAction.toDouble())
-      .withTypeAction(actionType)
+      .withTypeAction(reasonForAction)
       .withId(UUID.randomUUID().toString())
       .withDateAction(new Date());
 
-    account.getPaymentStatus().setName(actionType);
+    account.getPaymentStatus().setName(reasonForAction);
     account.getStatus().setName(CLOSED.getValue());
     account.setRemaining(0.0);
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODFEE-137 - Provide ability to specify cancellation reason in accounts/:id/cancel request.

## Changes:
* Bump `feesfines` API version to `16.1`
* Update `cancelActionRequest.json` schema with new `cancellationReason` property which defaulting to `Cancelled as error` value.
* Use the reason when an account is closed and set the reason to:
  * `account.paymentStatus.name`
  * `accountAction.typeAction`
* Add a test case to verify the new behavior.