### PR TITLE
MODFEE-145: Add property code to manual blocks

### DIFF
--- a/ramls/manualblockdata.json
+++ b/ramls/manualblockdata.json
@@ -12,6 +12,10 @@
       "description": "Patron block description",
       "type": "string"
     },
+    "code": {
+      "description": "Code of the template if block is defined based on a template (optional)",
+      "type": "string"
+    },
     "staffInformation": {
       "description": "Additional information to staff (optional)",
       "type": "string"


### PR DESCRIPTION
## Description
As [UIU-1911](https://issues.folio.org/browse/UIU-1911) specifies, manual patron blocks should have an optional field "block code". This code may be defined by block templates which were added by [MODFEE-133](https://issues.folio.org/browse/MODFEE-133).

This PR adds the optional field _code_ to the schema of manual blocks.

## Ticket
https://issues.folio.org/browse/MODFEE-145