### PR TITLE
MODFEE-146: Store new aged to lost settings for recalled items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 15.10.0 (In Progress)
 
-* Store new aged to lost settings for recalled items (https://issues.folio.org/browse/MODFEE-146)
+* Store new aged to lost settings for recalled items (MODFEE-146)
 
 ## 15.9.0 2020-10-14
 * Add loanId to the FEE_FINE_BALANCE_CHANGED event payload (MODFEE-71)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 15.10.0 (In Progress)
+
+* Store new aged to lost settings for recalled items (https://issues.folio.org/browse/MODFEE-146)
+
 ## 15.9.0 2020-10-14
 * Add loanId to the FEE_FINE_BALANCE_CHANGED event payload (MODFEE-71)
 * Extend/rename tokens available to manual fee/fine notices (MODFEE-72)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -54,7 +54,7 @@
   "provides":[
     {
       "id":"feesfines",
-      "version":"16.2",
+      "version":"16.3",
       "handlers":[
         {
           "methods":[

--- a/ramls/lost-item-fee-policy.json
+++ b/ramls/lost-item-fee-policy.json
@@ -22,6 +22,16 @@
       "type": "object",
       "$ref": "period.json"
     },
+    "recalledItemAgedLostOverdue": {
+      "description": "Recalled items aged to lost after overdue entered, must be 0 or > 0 and, if > 0 must have interval selected",
+      "type": "object",
+      "$ref": "period.json"
+    },
+    "patronBilledAfterRecalledItemAgedLost": {
+      "description": "Patron billed after a recalled item aged to lost entered, must be 0 or > 0 and, if > 0 must have interval selected",
+      "type": "object",
+      "$ref": "period.json"
+    },
     "chargeAmountItem": {
       "description": "Option to charge amount for item",
       "type": "object",

--- a/ramls/lost-item-fee-policy.raml
+++ b/ramls/lost-item-fee-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Lost Item Fee Policies
-version: v1.1
+version: v16.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/lost-item-fee-policy.raml
+++ b/ramls/lost-item-fee-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Lost Item Fee Policies
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
@@ -4,6 +4,8 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 
@@ -146,7 +148,10 @@ public class LostItemFeePoliciesAPITest extends ApiTests {
       .put("description", "This is description for undergrad standard")
       .put("itemAgedLostOverdue", new JsonObject().put("duration", 12).put("intervalId", "Months"))
       .put("patronBilledAfterAgedLost",
-        new JsonObject().put("duration", 12).put("intervalId", "Months"))
+        new JsonObject().put("duration", 5).put("intervalId", "Months"))
+      .put("recalledItemAgedLostOverdue", new JsonObject().put("duration", 12).put("intervalId", "Months"))
+      .put("patronBilledAfterRecalledItemAgedLost",
+        new JsonObject().put("duration", 6).put("intervalId", "Months"))
       .put("chargeAmountItem",
         new JsonObject().put("chargeType", "Actual cost").put("amount", 5.00))
       .put("lostItemProcessingFee", 5.00)


### PR DESCRIPTION
I added the requested fields to the RAML file for this policy type
this seems to make the build process automatically generate the
changes to the model and the underlying database.  I also inserted
the new fields in the lost item policy API test file.  Since this
file doesn't seem to check that any specific field exists in any
created policy, I didn't put in anything that specifically checks
for these fields either. However, I did confirm that that the fields
were present in the resulting posted policy by dumping the entire
response to screen and looking at it.  I also confirmed that if the
API was not expecting those fields or able to store them, it would
respond with a 422 error, which is not the case.

refs: https://issues.folio.org/browse/MODFEE-146