### PR TITLE
MODFEE-151 correctly specify permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## 15.10.0 (In Progress)
 
 * Store new aged to lost settings for recalled items (MODFEE-146)
-* Correctly specify permissions for DELETE /accounts/{id} (MODFEE-151)
+* Grants permission for messages to be published to pub-sub when deleting an account (MODFEE-151)
 
 ## 15.9.0 2020-10-14
 * Add loanId to the FEE_FINE_BALANCE_CHANGED event payload (MODFEE-71)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 15.10.0 (In Progress)
 
 * Store new aged to lost settings for recalled items (MODFEE-146)
+* Correctly specify permissions for DELETE /accounts/{id} (MODFEE-151)
 
 ## 15.9.0 2020-10-14
 * Add loanId to the FEE_FINE_BALANCE_CHANGED event payload (MODFEE-71)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -195,8 +195,10 @@
             "DELETE"
           ],
           "pathPattern":"/accounts/{id}",
-          "permissionsRequired":[
-            "accounts.item.delete",
+          "permissionsRequired": [
+            "accounts.item.delete"
+          ],
+          "modulePermissions": [
             "pubsub.publish.post"
           ]
         },


### PR DESCRIPTION
Some `modulePermissions` for the path `DELETE /accounts/{id}` were
incorrectly listed under `permissionsRequired` instead.

Fixes [MODFEE-151](https://issues.folio.org/browse/MODFEE-151)