### PR TITLE
MODFEE-170 Sort fee/fine actions by date

### DIFF
--- a/src/main/java/org/folio/rest/service/report/RefundReportService.java
+++ b/src/main/java/org/folio/rest/service/report/RefundReportService.java
@@ -445,12 +445,18 @@ public class RefundReportService {
 
   private Comparator<Feefineaction> actionDateComparator() {
     return (left, right) -> {
-      if (left.getDateAction() == null || right.getDateAction() == null
-        || left.getDateAction().equals(right.getDateAction())) {
+      if (left == null || right == null) {
+        return 0;
+      }
+
+      Date leftDate = left.getDateAction();
+      Date rightDate = right.getDateAction();
+
+      if (leftDate == null || rightDate == null || leftDate.equals(rightDate)) {
         return 0;
       } else {
-        return new DateTime(left.getDateAction())
-          .isAfter(new DateTime(right.getDateAction())) ? 1 : -1;
+        return new DateTime(leftDate)
+          .isAfter(new DateTime(rightDate)) ? 1 : -1;
       }
     };
   }

--- a/src/main/java/org/folio/rest/service/report/RefundReportService.java
+++ b/src/main/java/org/folio/rest/service/report/RefundReportService.java
@@ -14,6 +14,7 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.apache.commons.lang.StringUtils.defaultString;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Currency;
 import java.util.Date;
 import java.util.HashMap;
@@ -431,8 +432,21 @@ public class RefundReportService {
 
     return feeFineActionRepository.findActionsOfTypesForAccount(accountId,
       List.of(REFUND, PAY, TRANSFER))
+      .map(ffa -> ffa.stream().sorted(actionDateComparator()).collect(Collectors.toList()))
       .map(ctx.accounts.get(accountId)::withActions)
       .map(AccountContextData::getActions);
+  }
+
+  private Comparator<Feefineaction> actionDateComparator() {
+    return (left, right) -> {
+      if (left == null || right == null || left.getDateAction() == null
+        || right.getDateAction() == null || left.getDateAction().equals(right.getDateAction())) {
+        return 0;
+      } else {
+        return new DateTime(left.getDateAction())
+          .isAfter(new DateTime(right.getDateAction())) ? 1 : -1;
+      }
+    };
   }
 
   private void setUpLocale(LocaleSettings localeSettings) {

--- a/src/main/java/org/folio/rest/service/report/RefundReportService.java
+++ b/src/main/java/org/folio/rest/service/report/RefundReportService.java
@@ -439,8 +439,8 @@ public class RefundReportService {
 
   private Comparator<Feefineaction> actionDateComparator() {
     return (left, right) -> {
-      if (left == null || right == null || left.getDateAction() == null
-        || right.getDateAction() == null || left.getDateAction().equals(right.getDateAction())) {
+      if (left.getDateAction() == null || right.getDateAction() == null
+        || left.getDateAction().equals(right.getDateAction())) {
         return 0;
       } else {
         return new DateTime(left.getDateAction())

--- a/src/main/java/org/folio/rest/service/report/RefundReportService.java
+++ b/src/main/java/org/folio/rest/service/report/RefundReportService.java
@@ -3,6 +3,7 @@ package org.folio.rest.service.report;
 import static io.vertx.core.Future.succeededFuture;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ZERO;
+import static org.apache.commons.lang.StringUtils.defaultString;
 import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.REFUND;
 import static org.folio.rest.domain.Action.TRANSFER;
@@ -11,7 +12,6 @@ import static org.folio.rest.utils.AccountHelper.STAFF_COMMENTS_KEY;
 import static org.folio.rest.utils.AccountHelper.parseFeeFineComments;
 import static org.folio.util.UuidUtil.isUuid;
 import static org.joda.time.DateTimeZone.UTC;
-import static org.apache.commons.lang.StringUtils.defaultString;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -432,9 +432,15 @@ public class RefundReportService {
 
     return feeFineActionRepository.findActionsOfTypesForAccount(accountId,
       List.of(REFUND, PAY, TRANSFER))
-      .map(ffa -> ffa.stream().sorted(actionDateComparator()).collect(Collectors.toList()))
+      .map(this::sortFeeFineActionsByDate)
       .map(ctx.accounts.get(accountId)::withActions)
       .map(AccountContextData::getActions);
+  }
+
+  private List<Feefineaction> sortFeeFineActionsByDate(List<Feefineaction> feeFineActions) {
+    return feeFineActions.stream()
+      .sorted(actionDateComparator())
+      .collect(Collectors.toList());
   }
 
   private Comparator<Feefineaction> actionDateComparator() {

--- a/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
@@ -14,7 +14,7 @@ import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkPayClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkTransferClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkWaiveClient;
-import static org.folio.rest.utils.ResourceClients.feeFineActionsClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.test.support.matcher.FeeFineActionMatchers.feeFineAction;
 import static org.folio.test.support.matcher.LogEventMatcher.feeFineActionLogEventPayload;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -67,7 +67,7 @@ public class AccountsBulkPayWaiveTransferAPITests extends ApiTests {
   private static final List<String> FIRST_ACCOUNT_ID_AS_LIST = singletonList(FIRST_ACCOUNT_ID);
   private static final List<String> TWO_ACCOUNT_IDS = Arrays.asList(FIRST_ACCOUNT_ID, SECOND_ACCOUNT_ID);
 
-  private final ResourceClient actionsClient = feeFineActionsClient();
+  private final ResourceClient actionsClient = buildFeeFineActionsClient();
   private final Action action;
   private ResourceClient resourceClient;
 

--- a/src/test/java/org/folio/rest/impl/AccountsCancelActionAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsCancelActionAPITests.java
@@ -6,7 +6,7 @@ import static java.lang.String.format;
 import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkCancelClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountCancelClient;
-import static org.folio.rest.utils.ResourceClients.feeFineActionsClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.test.support.EntityBuilder.buildAccount;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.either;
@@ -39,7 +39,7 @@ public class AccountsCancelActionAPITests extends ApiTests {
   private static final String ACCOUNTS_TABLE = "accounts";
   private static final String ACCOUNT_ID = randomId();
 
-  private final ResourceClient actionsClient = feeFineActionsClient();
+  private final ResourceClient actionsClient = buildFeeFineActionsClient();
   private final ResourceClient accountCancelClient = buildAccountCancelClient(ACCOUNT_ID);
   private final ResourceClient accountBulkCancelClient = buildAccountBulkCancelClient();
 

--- a/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
@@ -13,7 +13,7 @@ import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountPayClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountTransferClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountWaiveClient;
-import static org.folio.rest.utils.ResourceClients.feeFineActionsClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.test.support.matcher.FeeFineActionMatchers.feeFineAction;
 import static org.folio.test.support.matcher.LogEventMatcher.feeFineActionLogEventPayload;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -54,7 +54,7 @@ public class AccountsPayWaiveTransferAPITests extends ApiTests {
   private static final String ACCOUNT_ID = randomId();
   private static final String FEE_FINE_ACTIONS = "feefineactions";
 
-  private final ResourceClient actionsClient = feeFineActionsClient();
+  private final ResourceClient actionsClient = buildFeeFineActionsClient();
   private final Action action;
   private ResourceClient resourceClient;
 

--- a/src/test/java/org/folio/rest/impl/AccountsRefundAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsRefundAPITests.java
@@ -18,7 +18,7 @@ import static org.folio.rest.utils.ResourceClients.buildAccountsRefundClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountPayClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountTransferClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountWaiveClient;
-import static org.folio.rest.utils.ResourceClients.feeFineActionsClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.test.support.matcher.LogEventMatcher.notCreditOrRefundActionLogEventPayload;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -79,7 +79,7 @@ public class AccountsRefundAPITests extends ApiTests {
   private static final String REFUNDED_TO_PATRON = "Refunded to patron";
   private static final String REFUNDED_TO_BURSAR = "Refunded to Bursar";
 
-  private final ResourceClient actionsClient = feeFineActionsClient();
+  private final ResourceClient actionsClient = buildFeeFineActionsClient();
   private final ResourceClient refundClient = buildAccountsRefundClient(FIRST_ACCOUNT_ID);
   private final ResourceClient bulkRefundClient = buildAccountBulkRefundClient();
 

--- a/src/test/java/org/folio/rest/impl/FeeFineReportsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineReportsAPITest.java
@@ -588,17 +588,22 @@ public class FeeFineReportsAPITest extends ApiTests {
     createAction(1, account, "2020-01-01 12:00:00", PAID_PARTIALLY, PAYMENT_METHOD,
       3.0, 7.0, PAYMENT_STAFF_INFO, PAYMENT_PATRON_INFO, PAYMENT_TX_INFO);
 
+    // Create transfer action with the same date to check it is sorted correctly
+    createAction(1, account, "2020-01-01 12:00:00",
+      TRANSFERRED_PARTIALLY, TRANSFER_ACCOUNT, 1.0, 4.5, "", "", TRANSFER_TX_INFO);
+
     // Create transfer action with null date to check that it is sorted correctly
     createAction(1, account, null,
-      TRANSFERRED_PARTIALLY, TRANSFER_ACCOUNT, 1.5, 8.5, "", "", TRANSFER_TX_INFO);
+      TRANSFERRED_PARTIALLY, TRANSFER_ACCOUNT, 0.5, 4.0, "", "", TRANSFER_TX_INFO);
 
     // Ensure that actions are returned in the wrong order
     feeFineActionsClient.getAll()
       .then()
-      .body(FEE_FINE_ACTIONS, hasSize(3))
+      .body(FEE_FINE_ACTIONS, hasSize(4))
       .body(FEE_FINE_ACTIONS + "[0]." + TYPE_ACTION, equalTo("Refunded partially"))
       .body(FEE_FINE_ACTIONS + "[1]." + TYPE_ACTION, equalTo("Paid partially"))
-      .body(FEE_FINE_ACTIONS + "[2]." + TYPE_ACTION, equalTo("Transferred partially"));
+      .body(FEE_FINE_ACTIONS + "[2]." + TYPE_ACTION, equalTo("Transferred partially"))
+      .body(FEE_FINE_ACTIONS + "[3]." + TYPE_ACTION, equalTo("Transferred partially"));
 
     requestAndCheck(List.of(
       buildRefundReportEntry(account, refundAction,

--- a/src/test/java/org/folio/rest/impl/FeeFineReportsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineReportsAPITest.java
@@ -588,7 +588,8 @@ public class FeeFineReportsAPITest extends ApiTests {
     createAction(1, account, "2020-01-01 12:00:00", PAID_PARTIALLY, PAYMENT_METHOD,
       3.0, 7.0, PAYMENT_STAFF_INFO, PAYMENT_PATRON_INFO, PAYMENT_TX_INFO);
 
-    createAction(1, account, "2020-01-02 12:00:00",
+    // Create transfer action with null date to check that it is sorted correctly
+    createAction(1, account, null,
       TRANSFERRED_PARTIALLY, TRANSFER_ACCOUNT, 1.5, 8.5, "", "", TRANSFER_TX_INFO);
 
     // Ensure that actions are returned in the wrong order
@@ -763,6 +764,10 @@ public class FeeFineReportsAPITest extends ApiTests {
   }
 
   private Date parseDateTime(String date) {
+    if (date == null) {
+      return null;
+    }
+
     return DateTime.parse(date, DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")).toDate();
   }
 

--- a/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
+++ b/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
@@ -4,7 +4,7 @@ import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.TRANSFER;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkCheckRefundClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountCheckRefundClient;
-import static org.folio.rest.utils.ResourceClients.feeFineActionsClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 
 import org.apache.http.HttpStatus;
 import org.folio.rest.impl.accountactionchecks.AccountsActionChecksAPITestsBase;
@@ -34,12 +34,12 @@ public class AccountsActionCheckBulkRefundAPITests extends AccountsActionChecksA
       .withUserId(firstAccount.getUserId())
       .withAmountAction((REQUESTED_AMOUNT + expectedRemainingAmount) / 2);
 
-    feeFineActionsClient()
+    buildFeeFineActionsClient()
       .post(feeFineAction.withTypeAction(PAY.getPartialResult()))
       .then()
       .statusCode(HttpStatus.SC_CREATED);
 
-    feeFineActionsClient()
+    buildFeeFineActionsClient()
       .post(feeFineAction.withTypeAction(TRANSFER.getPartialResult()))
       .then()
       .statusCode(HttpStatus.SC_CREATED);

--- a/src/test/java/org/folio/rest/utils/ResourceClients.java
+++ b/src/test/java/org/folio/rest/utils/ResourceClients.java
@@ -102,7 +102,7 @@ public final class ResourceClients {
     return new ResourceClient(format("/accounts-bulk/%s", action));
   }
 
-  public static ResourceClient feeFineActionsClient() {
+  public static ResourceClient buildFeeFineActionsClient() {
     return new ResourceClient("/feefineactions");
   }
 

--- a/src/test/java/org/folio/test/support/ApiTests.java
+++ b/src/test/java/org/folio/test/support/ApiTests.java
@@ -11,6 +11,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.rest.utils.ResourceClients.buildAccountClient;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.rest.utils.ResourceClients.buildFeeFinesClient;
 import static org.folio.rest.utils.ResourceClients.buildManualBlockClient;
 import static org.folio.rest.utils.ResourceClients.buildManualBlockTemplateClient;
@@ -68,6 +69,7 @@ public class ApiTests {
   protected static Vertx vertx;
 
   protected final ResourceClient accountsClient = buildAccountClient();
+  protected final ResourceClient feeFineActionsClient = buildFeeFineActionsClient();
   protected final ResourceClient manualBlocksClient = buildManualBlockClient();
   protected final ResourceClient feeFinesClient = buildFeeFinesClient();
   protected final ResourceClient manualBlockTemplatesClient = buildManualBlockTemplateClient();


### PR DESCRIPTION
Resolves [MODFEE-170](https://issues.folio.org/browse/MODFEE-170).

The issue is caused by fee/fine actions repository returning entries in the wrong order, e.g. refund action is listed before payment. This was fixed by sorting account's action list by date.