### PR TITLE
MODFEE-169: Add missing indexes

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -34,12 +34,16 @@
     },
     {
       "tableName":"accounts",
-      "fromModuleVersion":"15.0",
+      "fromModuleVersion":"15.9.2",
       "withMetadata":true,
       "index" : [
         {
           "fieldName" : "loanId",
           "tOps" : "ADD"
+        },
+        {
+          "fieldName": "userId",
+          "tOps": "ADD"
         }
       ]
     },
@@ -81,8 +85,14 @@
     },
     {
       "tableName":"manualblocks",
-      "fromModuleVersion":"15.0",
-      "withMetadata":true
+      "fromModuleVersion":"15.9.2",
+      "withMetadata":true,
+      "index" : [
+        {
+          "fieldName" : "userId",
+          "tOps" : "ADD"
+        }
+      ]
     },
     {
       "tableName":"manual_block_templates",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -34,7 +34,7 @@
     },
     {
       "tableName":"accounts",
-      "fromModuleVersion":"15.9.2",
+      "fromModuleVersion":"15.10.0",
       "withMetadata":true,
       "index" : [
         {

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -85,7 +85,7 @@
     },
     {
       "tableName":"manualblocks",
-      "fromModuleVersion":"15.9.2",
+      "fromModuleVersion":"15.10.0",
       "withMetadata":true,
       "index" : [
         {


### PR DESCRIPTION
Added two missing b-tree indexes for the field "userId" in the accounts and manualblocks tables.
I did not add an index for accounts.jsonb-->'status', as specified in the JIRA, because it is an enum table and only has a few values.