### PR TITLE
MODFEE-182 Fix Remaining amount calculation for refund action

### DIFF
--- a/src/main/java/org/folio/rest/repository/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/rest/repository/FeeFineActionRepository.java
@@ -4,7 +4,8 @@ import static io.vertx.core.Future.failedFuture;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.SPACE;
+import static org.folio.rest.domain.Action.PAY;
+import static org.folio.rest.domain.Action.TRANSFER;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,15 +13,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.folio.cql2pgjson.CQL2PgJSON;
-import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.domain.Action;
 import org.folio.rest.jaxrs.model.Feefineaction;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.GroupedCriterias;
+import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.utils.FeeFineActionHelper;
@@ -39,9 +38,8 @@ public class FeeFineActionRepository {
   private static final String ACCOUNTS_TABLE = "accounts";
   private static final String DATE_FIELD = "dateAction";
   private static final String TYPE_FIELD = "typeAction";
+  private static final String ACCOUNT_ID_FIELD = "accountId";
   private static final int ACTIONS_LIMIT = 1000;
-  private static final String FIND_REFUNDABLE_ACTIONS_QUERY_TEMPLATE =
-    "typeAction any \"Paid Transferred\" AND accountId any \"%s\"";
 
   private final PostgresClient pgClient;
   private final String tenantId;
@@ -85,7 +83,7 @@ public class FeeFineActionRepository {
       return failedFuture(new IllegalArgumentException("Types list is empty"));
     }
 
-    GroupedCriterias typeCriterias = groupCriterias(getTypeCriterias(types), "OR");
+    GroupedCriterias typeCriterias = buildGroupedCriterias(getTypeCriterias(types), "OR");
 
     Criterion criterion = new Criterion(new Criteria()
       .addField("'accountId'")
@@ -105,21 +103,23 @@ public class FeeFineActionRepository {
       return failedFuture(new IllegalArgumentException("List of account IDs is empty or null"));
     }
 
-    CQL2PgJSON cql2pgJson;
-    try {
-      cql2pgJson = new CQL2PgJSON(ACTIONS_TABLE + ".jsonb");
-    } catch (FieldException e) {
-      return failedFuture(e);
-    }
+    GroupedCriterias accountIdsCriterias = buildGroupedCriterias(
+      buildEqualsCriteriaList(ACCOUNT_ID_FIELD, accountIds), "OR");
 
-    String query = format(FIND_REFUNDABLE_ACTIONS_QUERY_TEMPLATE,
-      String.join(SPACE, accountIds));
+    GroupedCriterias typeCriterias = buildGroupedCriterias(
+      buildEqualsCriteriaList(TYPE_FIELD, List.of(PAY.getPartialResult(), PAY.getFullResult(),
+        TRANSFER.getPartialResult(), TRANSFER.getFullResult())), "OR");
 
-    CQLWrapper cqlWrapper = new CQLWrapper(cql2pgJson, query, ACTIONS_LIMIT, 0);
+    Criterion criterion = new Criterion()
+      .addGroupOfCriterias(typeCriterias)
+      .addGroupOfCriterias(accountIdsCriterias)
+      .setLimit(new Limit(ACTIONS_LIMIT));
+
     Promise<Results<Feefineaction>> promise = Promise.promise();
-    pgClient.get(ACTIONS_TABLE, Feefineaction.class, cqlWrapper, false, promise);
+    pgClient.get(ACTIONS_TABLE, Feefineaction.class, criterion, false, promise);
 
-    return promise.future().map(Results::getResults);
+    return promise.future()
+      .map(Results::getResults);
   }
 
   public Future<Feefineaction> findChargeForAccount(String accountId) {
@@ -207,6 +207,17 @@ public class FeeFineActionRepository {
       .collect(toList());
   }
 
+  private List<Criteria> buildEqualsCriteriaList(String fieldName, Collection<String> values) {
+    return values.stream()
+      .map(value ->
+        new Criteria()
+          .addField(format("'%s'", fieldName))
+          .setOperation("=")
+          .setVal(value)
+          .setJSONB(true))
+      .collect(toList());
+  }
+
   private List<Feefineaction> mapToFeeFineActions(RowSet<Row> rowSet) {
     RowIterator<Row> iterator = rowSet.iterator();
     List<Feefineaction> feeFineActions = new ArrayList<>();
@@ -216,7 +227,7 @@ public class FeeFineActionRepository {
     return feeFineActions;
   }
 
-  private GroupedCriterias groupCriterias(List<Criteria> criterias, String op) {
+  private GroupedCriterias buildGroupedCriterias(List<Criteria> criterias, String op) {
     GroupedCriterias groupedCriterias = new GroupedCriterias();
     criterias.forEach(criteria -> groupedCriterias.addCriteria(criteria, op));
     return groupedCriterias;

--- a/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
+++ b/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
@@ -1,13 +1,19 @@
 package org.folio.rest.impl.accountactionchecks.bulk;
 
+import static io.restassured.http.ContentType.JSON;
 import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.TRANSFER;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkCheckRefundClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountCheckRefundClient;
 import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.List;
+import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.folio.rest.impl.accountactionchecks.AccountsActionChecksAPITestsBase;
+import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.Feefineaction;
 import org.folio.rest.utils.ResourceClient;
 import org.junit.Before;
@@ -86,5 +92,49 @@ public class AccountsActionCheckBulkRefundAPITests extends AccountsActionChecksA
     removeAllFromTable(ACCOUNTS_TABLE);
     actionCheckShouldNotFailForNonExistentAccount(false, accountsCheckRefundClient);
     actionCheckShouldNotFailForNonExistentAccount(true, accountsBulkCheckRefundClient);
+  }
+
+  @Test
+  public void checkRefundAmountShouldBeCorrectWithSimilarAccountIds() {
+    String similarAccountId = firstAccount.getId().split("-")[0] + "-" +
+      String.join("-", List.of(UUID.randomUUID().toString().split("-")).subList(1, 5));
+    Account accountToPost = createAccount().withId(similarAccountId);
+    accountsClient.create(accountToPost)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .contentType(JSON);
+
+    final Feefineaction feeFineAction1 = new Feefineaction()
+      .withAccountId(firstAccount.getId())
+      .withUserId(firstAccount.getUserId())
+      .withAmountAction(5.0)
+      .withTypeAction(PAY.getPartialResult());
+
+    buildFeeFineActionsClient()
+      .post(feeFineAction1)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+
+    final Feefineaction feeFineAction2 = new Feefineaction()
+      .withAccountId(similarAccountId)
+      .withUserId(firstAccount.getUserId())
+      .withAmountAction(2.0)
+      .withTypeAction(PAY.getPartialResult());
+
+    buildFeeFineActionsClient()
+      .post(feeFineAction2)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+
+    String requestedAmount = "1.00";
+    final var request = createRequest(false, requestedAmount);
+    final var response = accountsCheckRefundClient.attemptCreate(request);
+    response
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("allowed", is(true))
+      .body("accountId", is(firstAccount.getId()))
+      .body("amount", is(requestedAmount))
+      .body("remainingAmount", is("4.00"));
   }
 }

--- a/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
+++ b/src/test/java/org/folio/rest/impl/accountactionchecks/bulk/AccountsActionCheckBulkRefundAPITests.java
@@ -95,9 +95,14 @@ public class AccountsActionCheckBulkRefundAPITests extends AccountsActionChecksA
   }
 
   @Test
-  public void checkRefundAmountShouldBeCorrectWithSimilarAccountIds() {
+  public void checkRefundRemainingAmountShouldBeCorrectWithSimilarAccountId() {
+    // We need to create an accountId that would have the same first segment as the existing
+    // accountId, but the rest of it would be different. This will demonstrate that we are
+    // filtering fee/fine actions by the whole UUIDs and not just by their parts as CQL's "any"
+    // filter would.
     String similarAccountId = firstAccount.getId().split("-")[0] + "-" +
       String.join("-", List.of(UUID.randomUUID().toString().split("-")).subList(1, 5));
+
     Account accountToPost = createAccount().withId(similarAccountId);
     accountsClient.create(accountToPost)
       .then()


### PR DESCRIPTION
Resolves [MODFEE-182](https://issues.folio.org/browse/MODFEE-182).

### Purpose
Remaining amount is not calculated correctly because of incorrect DB query.

### Approach
Replace CQL `any (uuid1, uuid2)` kind of filter with more strict SQL `(accountId = uuid1 OR accountId = uuid2)`.