### PR TITLE
MODFEE-187 - Search/filter on fees/fines not pulling recent circ log actions

### DIFF
--- a/src/main/java/org/folio/rest/impl/FeeFineActionsAPI.java
+++ b/src/main/java/org/folio/rest/impl/FeeFineActionsAPI.java
@@ -2,7 +2,6 @@ package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.folio.rest.domain.Action.CREDIT;
-import static org.folio.rest.domain.Action.REFUND;
 import static org.folio.rest.service.LogEventPublisher.LogEventPayloadType.FEE_FINE;
 
 import java.io.IOException;
@@ -164,20 +163,14 @@ public class FeeFineActionsAPI implements Feefineactions {
 
   private Future<Response> publishLogEvent(Feefineaction entity, Map<String, String> okapiHeaders,
     Context vertxContext, Response response) {
-
-    // do not publish log records for CREDIT and REFUND actions
-    if (!CREDIT.isActionForResult(entity.getTypeAction()) &&
-      !REFUND.isActionForResult(entity.getTypeAction())) {
-
-      return new LogEventService(vertxContext.owner(), okapiHeaders)
+    return new LogEventService(vertxContext.owner(), okapiHeaders)
         .createFeeFineLogEventPayload(entity)
         .compose(eventPayload -> {
-          new LogEventPublisher(vertxContext, okapiHeaders).publishLogEvent(eventPayload, FEE_FINE);
-          return Future.succeededFuture();
-        })
+              new LogEventPublisher(vertxContext, okapiHeaders)
+                  .publishLogEvent(eventPayload, FEE_FINE);
+              return Future.succeededFuture();
+            })
         .map(v -> response);
-    }
-    return Future.succeededFuture(response);
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/service/action/ActionService.java
+++ b/src/main/java/org/folio/rest/service/action/ActionService.java
@@ -6,7 +6,6 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.folio.rest.domain.Action.CREDIT;
-import static org.folio.rest.domain.Action.REFUND;
 import static org.folio.rest.domain.FeeFineStatus.CLOSED;
 import static org.folio.rest.persist.PostgresClient.getInstance;
 import static org.folio.rest.service.LogEventPublisher.LogEventPayloadType.FEE_FINE;
@@ -186,9 +185,8 @@ public abstract class ActionService {
 
   private Future<ActionContext> publishLogEvents(ActionContext actionContext) {
     return all(actionContext.getFeeFineActions().stream()
-      // do not publish log records for CREDIT and REFUND actions
-      .filter(ffa -> !CREDIT.isActionForResult(ffa.getTypeAction()) && !REFUND.isActionForResult(ffa.getTypeAction()))
-      .map(ffa -> logEventService.createFeeFineLogEventPayload(ffa, actionContext.getAccounts().get(ffa.getAccountId()))
+      .map(ffa -> logEventService.createFeeFineLogEventPayload(ffa,
+        actionContext.getAccounts().get(ffa.getAccountId()))
         .compose(eventPayload -> {
           logEventPublisher.publishLogEvent(eventPayload, FEE_FINE);
           return succeededFuture();

--- a/src/test/java/org/folio/rest/impl/AccountsRefundAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsRefundAPITests.java
@@ -18,7 +18,12 @@ import static org.folio.rest.utils.ResourceClients.buildAccountTransferClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountWaiveClient;
 import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountsRefundClient;
-import static org.folio.test.support.matcher.LogEventMatcher.notCreditOrRefundActionLogEventPayload;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfClosedAccountWithPaymentPayloads;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfClosedAccountWithTransferPayloads;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfClosedAccountWithPaymentAndTransferPayloads;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfOpenAccountWithPaymentPayloads;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfOpenAccountWithTransferPayloads;
+import static org.folio.test.support.matcher.LogEventMatcher.partialRefundOfOpenAccountWithPaymentAndTransferPayloads;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -214,6 +219,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       CLOSED, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfClosedAccountWithPaymentPayloads())));
+    assertThat(payloads, hasSize(4));
   }
 
   @Test
@@ -231,6 +240,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       CLOSED, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfClosedAccountWithTransferPayloads())));
+    assertThat(payloads, hasSize(4));
   }
 
   @Test
@@ -252,6 +265,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       CLOSED, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfClosedAccountWithPaymentAndTransferPayloads())));
+    assertThat(payloads, hasSize(7));
   }
 
   @Test
@@ -269,6 +286,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       OPEN, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfOpenAccountWithPaymentPayloads())));
+    assertThat(payloads, hasSize(4));
   }
 
   @Test
@@ -286,6 +307,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       OPEN, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfOpenAccountWithTransferPayloads())));
+    assertThat(payloads, hasSize(4));
   }
 
   @Test
@@ -307,6 +332,10 @@ public class AccountsRefundAPITests extends ActionsAPITests {
 
     testSingleAccountRefundSuccess(initialAmount, payAmount, transferAmount, waiveAmount, refundAmount,
       OPEN, REFUND.getPartialResult(), expectedFeeFineActions);
+
+    List<String> payloads = fetchLogEventPayloads(getOkapi());
+    payloads.forEach(payload -> assertThat(payload, is(partialRefundOfOpenAccountWithPaymentAndTransferPayloads())));
+    assertThat(payloads, hasSize(7));
   }
 
   @Test
@@ -425,9 +454,6 @@ public class AccountsRefundAPITests extends ActionsAPITests {
       REFUND.getPartialResult(), expectedRemainingAmount3, OPEN.getValue());
 
     verifyThatFeeFineBalanceChangedEventsWereSent(firstAccount, secondAccount, thirdAccount);
-
-    fetchLogEventPayloads(getOkapi()).forEach(payload ->
-      assertThat(payload, is(notCreditOrRefundActionLogEventPayload())));
   }
 
   @Test
@@ -598,9 +624,6 @@ public class AccountsRefundAPITests extends ActionsAPITests {
       expectedPaymentStatus, expectedRemainingAmount, expectedStatus.getValue());
 
     verifyThatFeeFineBalanceChangedEventsWereSent(accountAfterRefund);
-
-    fetchLogEventPayloads(getOkapi()).forEach(payload ->
-      assertThat(payload, is(notCreditOrRefundActionLogEventPayload())));
   }
 
   private void verifyResponse(Response response, double requestedAmount, int expectedActionsCount) {

--- a/src/test/java/org/folio/test/support/matcher/LogEventMatcher.java
+++ b/src/test/java/org/folio/test/support/matcher/LogEventMatcher.java
@@ -2,7 +2,10 @@ package org.folio.test.support.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.folio.rest.domain.Action.CREDIT;
+import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.REFUND;
+import static org.folio.rest.domain.Action.TRANSFER;
+import static org.folio.rest.domain.Action.WAIVE;
 import static org.folio.rest.domain.logs.LogEventPayloadField.ACTION;
 import static org.folio.rest.domain.logs.LogEventPayloadField.AMOUNT;
 import static org.folio.rest.domain.logs.LogEventPayloadField.BALANCE;
@@ -19,6 +22,7 @@ import static org.folio.rest.domain.logs.LogEventPayloadField.SOURCE;
 import static org.folio.rest.domain.logs.LogEventPayloadField.USER_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -102,8 +106,57 @@ public class LogEventMatcher {
       hasJsonPath(COMMENTS.value(), is(comments))));
   }
 
-  public static Matcher<? super Object> notCreditOrRefundActionLogEventPayload() {
-    return hasJsonPath(ACTION.value(), not(anyOf(is(CREDIT.getFullResult()), is(CREDIT.getPartialResult()),
-        is(REFUND.getPartialResult()), is(REFUND.getPartialResult()))));
+  public static Matcher<? super Object> partialRefundOfClosedAccountWithPaymentPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(WAIVE.getFullResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getPartialResult()),
+      is(PAY.getPartialResult())));
+  }
+
+  public static Matcher<? super Object> partialRefundOfClosedAccountWithTransferPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(TRANSFER.getFullResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getPartialResult()),
+      is(WAIVE.getPartialResult())));
+  }
+
+  public static Matcher<? super Object> partialRefundOfOpenAccountWithPaymentPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(PAY.getPartialResult()),
+      is(WAIVE.getPartialResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getPartialResult())));
+  }
+
+  public static Matcher<? super Object> partialRefundOfOpenAccountWithTransferPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(TRANSFER.getPartialResult()),
+      is(WAIVE.getPartialResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getPartialResult())));
+  }
+
+  public static Matcher<? super Object> partialRefundOfClosedAccountWithPaymentAndTransferPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(PAY.getPartialResult()),
+      is(WAIVE.getPartialResult()),
+      is(TRANSFER.getFullResult()),
+      is(CREDIT.getFullResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getFullResult()),
+      is(REFUND.getPartialResult())));
+  }
+
+  public static Matcher<? super Object> partialRefundOfOpenAccountWithPaymentAndTransferPayloads() {
+    return hasJsonPath(ACTION.value(), anyOf(
+      is(PAY.getPartialResult()),
+      is(WAIVE.getPartialResult()),
+      is(TRANSFER.getPartialResult()),
+      is(CREDIT.getFullResult()),
+      is(CREDIT.getPartialResult()),
+      is(REFUND.getFullResult()),
+      is(REFUND.getPartialResult())));
   }
 }


### PR DESCRIPTION
JIRA issue: https://issues.folio.org/browse/MODFEE-187

### Purpose
When creating new circulation action, like fees/fines - refunded partially, filtering by user barcode, item barcode or fee/fine drop down filters don't show actions

### Approach
- Changed Refund and Credit actions to be processed by logEventService and published as FeeFineLogEvent
- Changed tests