### PR TITLE
MODFEE-195 Change maven-model dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>3.3.9</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Resolves [MODFEE-195](https://issues.folio.org/browse/MODFEE-195)

### Approach
`maven-model` dependency shouldn't have `test` scope because it's used by pub-sub client utils.