### PR TITLE
MODFEE-202 - Circulation log record event should contain staff information content

### DIFF
--- a/src/main/java/org/folio/rest/domain/logs/LogEventPayloadHelper.java
+++ b/src/main/java/org/folio/rest/domain/logs/LogEventPayloadHelper.java
@@ -95,6 +95,7 @@ public class LogEventPayloadHelper {
         write(json, COMMENTS.value(), act.getComments());
       } else if (STAFF_INFO_ONLY.equalsIgnoreCase(act.getTypeAction())) {
         write(json, ACTION.value(), STAFF_INFO_ONLY_ADDED);
+        write(json, COMMENTS.value(), act.getComments());
       } else if (isCharge(act)) {
         write(json, ACTION.value(), BILLED);
       }

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -79,6 +79,8 @@ public class FeeFineActionsAPITest extends ApiTests {
   private static final String CHARGE_COMMENT_FOR_PATRON = "Charge comment";
   private static final String ACTION_COMMENT_FOR_PATRON = "Action comment";
 
+  private static final String STAFF_INFO = "STAFF : staff comment \n PATRON : patron comment";
+
   private static final String ACCOUNT_AMOUNT = "12.34";
   private static final String ACCOUNT_REMAINING = "5.67";
   private static final String ACTION_AMOUNT = "6.67";
@@ -341,7 +343,8 @@ public class FeeFineActionsAPITest extends ApiTests {
       .put("action", expectedTypeAction)
       .put("feeFineId", feeFineId)
       .put("type", feeFineType)
-      .put("amount", amountAction);
+      .put("amount", amountAction)
+      .put("comments", STAFF_INFO);
 
     assertThatPublishedLogRecordsCountIsEqualTo(1);
     assertThatLogPayloadIsValid(expectedFeeFineLogContext, extractLastLogRecordPayloadOfType(FEE_FINE));
@@ -386,7 +389,7 @@ public class FeeFineActionsAPITest extends ApiTests {
     return new JsonObject()
       .put("dateAction", dateAction)
       .put("typeAction", typeAction)
-      .put("comments", "STAFF : staff comment \n PATRON : patron comment")
+      .put("comments", STAFF_INFO)
       .put("notify", notify)
       .put("amountAction", amountAction)
       .put("balance", balance)


### PR DESCRIPTION
[MODFEE-202](https://issues.folio.org/browse/MODFEE-202) - Circulation log record event should contain staff information content

* added "comments" field to the circulation log record event body
* updated unit tests