### PR TITLE
MODFEE-236 Update RMB to v33.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
     <powermock.version>2.0.7</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>33.0.4</raml-module-builder.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <vertx.version>4.1.5</vertx.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>
     <!-- Postgres port for Jenkins CI build environment https://issues.folio.org/browse/METADATA-10 -->
     <postgres.port>5433</postgres.port>
     <sonar.exclusions>**/impl/**</sonar.exclusions>
-    <junit.jupiter.version>5.5.1</junit.jupiter.version>
+    <junit.jupiter.version>5.6.0</junit.jupiter.version>
   </properties>
 
   <dependencyManagement>
@@ -35,16 +35,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
@@ -63,7 +63,7 @@ public class LostItemFeePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must not be null")
       .put("type", "1")
-      .put("code", "-1")
+      .put("code", "javax.validation.constraints.NotNull.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()
@@ -105,7 +105,7 @@ public class LostItemFeePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must match \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$\"")
       .put("type", "1")
-      .put("code", "-1")
+      .put("code", "javax.validation.constraints.Pattern.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()

--- a/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
@@ -62,7 +62,7 @@ public class OverdueFinePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must not be null")
       .put("type", "1")
-      .put("code", "-1")
+      .put("code", "javax.validation.constraints.NotNull.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()
@@ -104,7 +104,7 @@ public class OverdueFinePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must match \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$\"")
       .put("type", "1")
-      .put("code", "-1")
+      .put("code", "javax.validation.constraints.Pattern.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()


### PR DESCRIPTION
### Purpose
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to update RMB
### Approach
•	Updated RMB version
•	Updated Vertx version
•	Removed FOLIO fork of the vertx-sql-client and vertx-pg-client
•	Tests fixed
### Learning
https://issues.folio.org/browse/MODFEE-236
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
