### PR TITLE
MODFEE-220: Make paymentStatus property in accountdata.json required and also make it an enum

### DIFF
--- a/ramls/accountdata.json
+++ b/ramls/accountdata.json
@@ -38,17 +38,9 @@
       ]
     },
     "paymentStatus": {
-      "description": "Overall status of the payment/waive/transfer/refund/cancel",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Name of the status (values used are Outstanding, Paid partially, Paid fully, Waived partially, Waived fully, Transferred partially, Transferred fully, Refunded partially, Refunded fully, Cancelled as error)",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ]
+      "description": "Overall status of the payment/waive/transfer/refund/credit/cancel",
+      "type": "string",
+      "enum": ["Outstanding", "Paid partially", "Paid fully", "Waived partially", "Waived fully", "Transferred partially", "Transferred fully", "Refunded partially", "Refunded fully", "Credited fully", "Credited partially", "Cancelled item returned", "Cancelled as error"]
     },
     "feeFineType": {
       "description": "Fee/fine that is up to the desecration of the user",
@@ -170,6 +162,7 @@
     "userId",
     "feeFineId",
     "ownerId",
+    "paymentStatus",
     "id"
    ]
 }

--- a/src/main/java/org/folio/rest/service/action/ActionService.java
+++ b/src/main/java/org/folio/rest/service/action/ActionService.java
@@ -151,7 +151,7 @@ public abstract class ActionService {
       .withId(UUID.randomUUID().toString())
       .withDateAction(new Date());
 
-    account.getPaymentStatus().setName(actionType);
+    account.setPaymentStatus(Account.PaymentStatus.fromValue(actionType));
 
     if (isFullAction) {
       account.getStatus().setName(CLOSED.getValue());

--- a/src/main/java/org/folio/rest/service/action/CancelActionService.java
+++ b/src/main/java/org/folio/rest/service/action/CancelActionService.java
@@ -2,7 +2,6 @@ package org.folio.rest.service.action;
 
 import static org.folio.rest.domain.FeeFineStatus.CLOSED;
 
-import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -52,7 +51,7 @@ public class CancelActionService extends ActionService {
       .withId(UUID.randomUUID().toString())
       .withDateAction(new Date());
 
-    account.getPaymentStatus().setName(reasonForAction);
+    account.setPaymentStatus(Account.PaymentStatus.fromValue(reasonForAction));
     account.getStatus().setName(CLOSED.getValue());
     account.setRemaining(MonetaryValue.ZERO);
 

--- a/src/main/java/org/folio/rest/service/action/RefundActionService.java
+++ b/src/main/java/org/folio/rest/service/action/RefundActionService.java
@@ -6,10 +6,11 @@ import static org.folio.rest.domain.Action.CREDIT;
 import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.REFUND;
 import static org.folio.rest.domain.FeeFineStatus.OPEN;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.fromValue;
 import static org.folio.rest.utils.FeeFineActionHelper.getTotalAmount;
 import static org.folio.rest.utils.FeeFineActionHelper.getTotalAmounts;
-import static org.folio.rest.utils.FeeFineActionHelper.groupTransferredAmountsByTransferAccount;
 import static org.folio.rest.utils.FeeFineActionHelper.groupFeeFineActionsByAccountId;
+import static org.folio.rest.utils.FeeFineActionHelper.groupTransferredAmountsByTransferAccount;
 
 import java.util.Date;
 import java.util.List;
@@ -161,7 +162,7 @@ public class RefundActionService extends ActionService {
 
   private static void updateAccountInMemory(Account account, Feefineaction feeFineAction) {
     account.setRemaining(feeFineAction.getBalance());
-    account.getPaymentStatus().setName(feeFineAction.getTypeAction());
+    account.setPaymentStatus(fromValue(feeFineAction.getTypeAction()));
     account.getStatus().setName(OPEN.getValue());
   }
 

--- a/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
+++ b/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
@@ -158,7 +158,7 @@ public class PatronNoticeBuilder {
     }
 
     String paymentStatus = account.getPaymentStatus() == null ?
-      null : account.getPaymentStatus().getName();
+      null : account.getPaymentStatus().value();
 
     feeChargeContext
       .put("owner", account.getFeeFineOwner())

--- a/src/test/java/org/folio/rest/domain/MonetaryValueSerializerTest.java
+++ b/src/test/java/org/folio/rest/domain/MonetaryValueSerializerTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.domain;
 
 import static io.restassured.http.ContentType.JSON;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
@@ -10,7 +11,6 @@ import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.Account;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
 import org.folio.test.support.ApiTests;
 import org.junit.After;
@@ -148,7 +148,7 @@ public class MonetaryValueSerializerTest extends ApiTests {
       .withFeeFineOwner("owner")
       .withAmount(new MonetaryValue(amount))
       .withRemaining(new MonetaryValue("3.33"))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 }

--- a/src/test/java/org/folio/rest/impl/AccountsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AccountsAPITest.java
@@ -8,13 +8,16 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static io.restassured.http.ContentType.JSON;
 import static io.vertx.core.json.Json.decodeValue;
 import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.PAID_FULLY;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.PAID_PARTIALLY;
 import static org.folio.test.support.matcher.AccountMatchers.isPaidFully;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -32,11 +35,10 @@ import org.awaitility.Awaitility;
 import org.folio.rest.domain.EventType;
 import org.folio.rest.domain.MonetaryValue;
 import org.folio.rest.jaxrs.model.Account;
+import org.folio.rest.jaxrs.model.ContributorData;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
-import org.folio.rest.jaxrs.model.ContributorData;
 import org.folio.test.support.ApiTests;
 import org.folio.test.support.matcher.TypeMappingMatcher;
 import org.hamcrest.Matcher;
@@ -151,7 +153,7 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Closed"))
-      .put("paymentStatus", createNamedObject("Paid fully"))
+      .put("paymentStatus", PAID_FULLY)
       .put("remaining", 0.0);
 
     accountsClient.update(accountId, updatedAccount);
@@ -188,7 +190,7 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Closed"))
-      .put("paymentStatus", createNamedObject("Paid fully"))
+      .put("paymentStatus", PAID_FULLY)
       .put("remaining", 0.0);
 
     accountsClient.update(accountId, updatedAccount);
@@ -212,14 +214,14 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Closed"))
-      .put("paymentStatus", createNamedObject("Paid partially"))
+      .put("paymentStatus", PAID_PARTIALLY)
       .put("remaining", 0.1);
 
     accountsClient.update(accountId, updatedAccount);
 
     assertThat(accountsClient.getById(accountId).body().asString(), allOf(
       hasJsonPath("status.name", is("Closed")),
-      hasJsonPath("paymentStatus.name", is("Paid partially")),
+      hasJsonPath("paymentStatus", is(PAID_PARTIALLY.value())),
       hasJsonPath("remaining", is(0.1))
     ));
     assertThat(getLastFeeFineClosedEvent(), nullValue());
@@ -237,7 +239,7 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Closed"))
-      .put("paymentStatus", createNamedObject("Paid fully"))
+      .put("paymentStatus", PAID_FULLY)
       .put("remaining", 0.0);
 
     accountsClient.update(accountId, updatedAccount);
@@ -258,14 +260,14 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Open"))
-      .put("paymentStatus", createNamedObject("Paid fully"))
+      .put("paymentStatus", PAID_FULLY)
       .put("remaining", 0.0);
 
     accountsClient.update(accountId, updatedAccount);
 
     assertThat(accountsClient.getById(accountId).getBody().asString(), allOf(
       hasJsonPath("status.name", is("Open")),
-      hasJsonPath("paymentStatus.name", is("Paid fully")),
+      hasJsonPath("paymentStatus", is(PAID_FULLY.value())),
       hasJsonPath("remaining", is(0.0))
     ));
     assertThat(getLastFeeFineClosedEvent(), nullValue());
@@ -288,7 +290,7 @@ public class AccountsAPITest extends ApiTests {
 
     final JsonObject updatedAccount = account.copy()
       .put("status", createNamedObject("Closed"))
-      .put("paymentStatus", createNamedObject("Paid fully"))
+      .put("paymentStatus", PAID_FULLY)
       .put("remaining", remaining.toDouble());
 
     accountsClient.attemptUpdate(accountId, updatedAccount)
@@ -351,7 +353,7 @@ public class AccountsAPITest extends ApiTests {
       .withFeeFineOwner("owner")
       .withAmount(new MonetaryValue(new BigDecimal("7.77")))
       .withRemaining(new MonetaryValue(new BigDecimal("3.33")))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 

--- a/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.TRANSFER;
 import static org.folio.rest.domain.Action.WAIVE;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
 import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkPayClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkTransferClient;
@@ -39,7 +40,6 @@ import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.DefaultBulkActionRequest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.utils.ResourceClient;
 import org.folio.test.support.ActionsAPITests;
@@ -352,7 +352,7 @@ public class AccountsBulkPayWaiveTransferAPITests extends ActionsAPITests {
       .withFeeFineOwner("owner")
       .withAmount(new MonetaryValue(amount))
       .withRemaining(new MonetaryValue(amount))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 

--- a/src/test/java/org/folio/rest/impl/AccountsCancelActionAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsCancelActionAPITests.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.CANCELLED_AS_ERROR;
 import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountBulkCancelClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountCancelClient;
@@ -65,7 +66,7 @@ public class AccountsCancelActionAPITests extends ApiTests {
       .statusCode(HttpStatus.SC_OK)
       .contentType(JSON)
       .body("status.name", is("Closed"))
-      .body("paymentStatus.name", is("Cancelled as error"))
+      .body("paymentStatus", is(CANCELLED_AS_ERROR.value()))
       .body("remaining", is(0.0f));
 
     actionsClient.getAll()
@@ -76,7 +77,7 @@ public class AccountsCancelActionAPITests extends ApiTests {
         hasJsonPath("amountAction",
           is((float) accountToPost.getAmount().toDouble())),
         hasJsonPath("balance", is(0.0f)),
-        hasJsonPath("typeAction", is("Cancelled as error"))
+        hasJsonPath("typeAction", is(CANCELLED_AS_ERROR.value()))
       )));
 
     assertThat(fetchLogEventPayloads(getOkapi()).get(0),
@@ -100,7 +101,7 @@ public class AccountsCancelActionAPITests extends ApiTests {
       .statusCode(HttpStatus.SC_OK)
       .contentType(JSON)
       .body("status.name", is("Closed"))
-      .body("paymentStatus.name", is(cancellationReason))
+      .body("paymentStatus", is(cancellationReason))
       .body("remaining", is(0.0f));
 
     actionsClient.getAll()
@@ -178,7 +179,7 @@ public class AccountsCancelActionAPITests extends ApiTests {
       .statusCode(HttpStatus.SC_OK)
       .contentType(JSON)
       .body("status.name", is("Closed"))
-      .body("paymentStatus.name", is("Cancelled as error"))
+      .body("paymentStatus", is(CANCELLED_AS_ERROR.value()))
       .body("remaining", is(0.0f)));
 
     actionsClient.getAll()
@@ -190,13 +191,13 @@ public class AccountsCancelActionAPITests extends ApiTests {
         hasJsonPath("amountAction", is(
           (float) accountsToPost.get(0).getAmount().toDouble())),
         hasJsonPath("balance", is(0.0f)),
-        hasJsonPath("typeAction", is("Cancelled as error"))
+        hasJsonPath("typeAction", is(CANCELLED_AS_ERROR.value()))
       )))
       .body(FEE_FINE_ACTIONS, hasItem(allOf(
         hasJsonPath("accountId", is(accountIds.get(1))),
         hasJsonPath("amountAction", is(accountsToPost.get(1).getAmount().getAmount().floatValue())),
         hasJsonPath("balance", is(0.0f)),
-        hasJsonPath("typeAction", is("Cancelled as error"))
+        hasJsonPath("typeAction", is(CANCELLED_AS_ERROR.value()))
         )
       ));
 

--- a/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
@@ -9,6 +9,7 @@ import static java.lang.String.format;
 import static org.folio.rest.domain.Action.PAY;
 import static org.folio.rest.domain.Action.TRANSFER;
 import static org.folio.rest.domain.Action.WAIVE;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
 import static org.folio.rest.utils.LogEventUtils.fetchLogEventPayloads;
 import static org.folio.rest.utils.ResourceClients.buildAccountPayClient;
 import static org.folio.rest.utils.ResourceClients.buildAccountTransferClient;
@@ -36,7 +37,6 @@ import org.folio.rest.jaxrs.model.ActionFailureResponse;
 import org.folio.rest.jaxrs.model.DefaultActionRequest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.utils.ResourceClient;
 import org.folio.test.support.ActionsAPITests;
@@ -322,7 +322,7 @@ public class AccountsPayWaiveTransferAPITests extends ActionsAPITests {
       .withFeeFineOwner("owner")
       .withAmount(new MonetaryValue(amount))
       .withRemaining(new MonetaryValue(amount))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -10,6 +10,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.PAID_FULLY;
 import static org.folio.rest.service.LogEventPublisher.LogEventPayloadType.FEE_FINE;
 import static org.folio.rest.service.LogEventPublisher.LogEventPayloadType.NOTICE;
 import static org.folio.rest.service.LogEventPublisher.LogEventPayloadType.NOTICE_ERROR;
@@ -68,7 +70,6 @@ import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Library;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Owner;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.service.LogEventPublisher.LogEventPayloadType;
 import org.folio.test.support.ApiTests;
@@ -340,7 +341,7 @@ public class FeeFineActionsAPITest extends ApiTests {
         .put("feeCharge", new JsonObject()
           .put("owner", account.getFeeFineOwner())
           .put("type", account.getFeeFineType())
-          .put("paymentStatus", account.getPaymentStatus().getName())
+          .put("paymentStatus", account.getPaymentStatus())
           .put("amount", ACCOUNT_AMOUNT)
           .put("remainingAmount", ACCOUNT_REMAINING)
           .put("chargeDate", accountCreationDate)
@@ -446,6 +447,7 @@ public class FeeFineActionsAPITest extends ApiTests {
       .put("materialTypeId", randomId())
       .put("feeFineId", feeFineId)
       .put("ownerId", ownerId)
+      .put("paymentStatus", OUTSTANDING)
       .put("remaining", 10.0)
       .put("amount", 10.0));
 
@@ -500,6 +502,7 @@ public class FeeFineActionsAPITest extends ApiTests {
       .put("itemId", randomId())
       .put("materialTypeId", randomId())
       .put("feeFineId", feeFineId)
+      .put("paymentStatus", OUTSTANDING)
       .put("ownerId", ownerId)
       .put("remaining", 10.0)
       .put("amount", 10.0));
@@ -670,7 +673,7 @@ public class FeeFineActionsAPITest extends ApiTests {
       .withTitle("Account-level title")
       .withCallNumber("Account-level call number")
       .withLocation("Account-level location")
-      .withPaymentStatus(new PaymentStatus().withName("Paid fully"))
+      .withPaymentStatus(PAID_FULLY)
       .withFeeFineType(feefine.getFeeFineType())
       .withMaterialType("book")
       .withMaterialTypeId(randomId())

--- a/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
+++ b/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.utils;
 
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.PAID_PARTIALLY;
 import static org.folio.rest.utils.FeeFineActionHelper.parseFeeFineComments;
 import static org.folio.rest.utils.PatronNoticeBuilder.buildNotice;
 import static org.hamcrest.Matchers.allOf;
@@ -34,7 +35,6 @@ import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.Owner;
 import org.folio.rest.jaxrs.model.PatronNotice;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Personal;
 import org.folio.rest.jaxrs.model.User;
 import org.joda.time.DateTime;
@@ -134,7 +134,7 @@ public class PatronNoticeBuilderTest {
 
     assertEquals(account.getFeeFineOwner(), chargeContext.getString("owner"));
     assertEquals(account.getFeeFineType(), chargeContext.getString("type"));
-    assertEquals(account.getPaymentStatus().getName(), chargeContext.getString("paymentStatus"));
+    assertEquals(account.getPaymentStatus().value(), chargeContext.getString("paymentStatus"));
     assertEquals(ACCOUNT_AMOUNT, chargeContext.getString("amount"));
     assertEquals(ACCOUNT_REMAINING, chargeContext.getString("remainingAmount"));
     assertEquals(dateToString(account.getMetadata().getCreatedDate()), chargeContext.getString("chargeDate"));
@@ -268,7 +268,7 @@ public class PatronNoticeBuilderTest {
       .withTitle("Account-level title")
       .withCallNumber("Account-level call number")
       .withLocation("Account-level location")
-      .withPaymentStatus(new PaymentStatus().withName("Partially paid"))
+      .withPaymentStatus(PAID_PARTIALLY)
       .withFeeFineOwner("Owner")
       .withFeeFineType("Fine type")
       .withMaterialType("book")

--- a/src/test/java/org/folio/test/support/ActionsAPITests.java
+++ b/src/test/java/org/folio/test/support/ActionsAPITests.java
@@ -22,7 +22,7 @@ public abstract class ActionsAPITests extends ApiTests {
       .then()
       .body("remaining", is((float) amount.toDouble()))
       .body("status.name", is(statusName))
-      .body("paymentStatus.name", is(expectedPaymentStatus))
+      .body("paymentStatus", is(expectedPaymentStatus))
       .body("metadata.updatedDate", notNullValue());
 
     final Account updatedAccount = getAccountByIdResponse.as(Account.class);

--- a/src/test/java/org/folio/test/support/EntityBuilder.java
+++ b/src/test/java/org/folio/test/support/EntityBuilder.java
@@ -1,6 +1,7 @@
 package org.folio.test.support;
 
 import static java.lang.String.format;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.OUTSTANDING;
 import static org.folio.test.support.ApiTests.randomId;
 
 import java.math.BigDecimal;
@@ -32,7 +33,6 @@ import org.folio.rest.jaxrs.model.LostItemFeePolicy;
 import org.folio.rest.jaxrs.model.ManualBlockTemplate;
 import org.folio.rest.jaxrs.model.Manualblock;
 import org.folio.rest.jaxrs.model.OverdueFinePolicy;
-import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Personal;
 import org.folio.rest.jaxrs.model.ReportTotalsEntry;
 import org.folio.rest.jaxrs.model.ServicePoint;
@@ -80,7 +80,7 @@ public class EntityBuilder {
       .withFeeFineOwner(owner)
       .withAmount(new MonetaryValue(amount))
       .withRemaining(new MonetaryValue(amount))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 
@@ -97,7 +97,7 @@ public class EntityBuilder {
       .withFeeFineOwner("owner")
       .withAmount(new MonetaryValue(9.0))
       .withRemaining(new MonetaryValue(4.55))
-      .withPaymentStatus(new PaymentStatus().withName("Outstanding"))
+      .withPaymentStatus(OUTSTANDING)
       .withStatus(new Status().withName("Open"));
   }
 

--- a/src/test/java/org/folio/test/support/matcher/AccountMatchers.java
+++ b/src/test/java/org/folio/test/support/matcher/AccountMatchers.java
@@ -1,6 +1,7 @@
 package org.folio.test.support.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.folio.rest.jaxrs.model.Account.PaymentStatus.PAID_FULLY;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -17,7 +18,7 @@ public final class AccountMatchers {
       response -> response.getBody().asString(),
       allOf(
         hasJsonPath("status.name", is("Closed")),
-        hasJsonPath("paymentStatus.name", is("Paid fully")),
+        hasJsonPath("paymentStatus", is(PAID_FULLY.value())),
         hasJsonPath("remaining", is(0.0))
       ));
   }


### PR DESCRIPTION
## Purpose
[MODFEE-220](https://issues.folio.org/browse/MODFEE-220)
_Make paymentStatus property in accountdata.json required and also make it an enum_