### PR TITLE
MODFEE-249 Fix 500 error while exporting Refunds to process manually report

### DIFF
--- a/src/main/java/org/folio/rest/service/report/RefundReportService.java
+++ b/src/main/java/org/folio/rest/service/report/RefundReportService.java
@@ -210,7 +210,9 @@ public class RefundReportService {
         log.error("Transfer amount is null - fee/fine action {}, account {}", feeFineAction.getId(),
           accountId);
       }
-    } else if (actionIsOfType(feeFineAction, REFUND)) {
+    } else if (actionIsOfType(feeFineAction, REFUND)
+      && ctx.refunds.containsKey(feeFineAction.getId())) {
+
       RefundData refundData = ctx.refunds.get(feeFineAction.getId());
       RefundReportEntry reportEntry = refundData.reportEntry;
 

--- a/src/test/java/org/folio/rest/impl/RefundReportTest.java
+++ b/src/test/java/org/folio/rest/impl/RefundReportTest.java
@@ -628,13 +628,13 @@ public class RefundReportTest extends FeeFineReportsAPITestBase {
     Account account1 = charge(USER_ID_1, 10.0, "ff-type-1", item1.getId(), OWNER_ID_1);
     createAction(1, account1, "2020-01-03 12:00:00", PAID_PARTIALLY, PAYMENT_METHOD,
       8.0, 2.0, PAYMENT_STAFF_INFO, PAYMENT_PATRON_INFO, PAYMENT_TX_INFO);
-    Feefineaction refundAction1 = createAction(1, account1, "2019-12-30 12:00:00",
+    createAction(1, account1, "2019-12-30 12:00:00",
       REFUNDED_PARTIALLY, REFUND_REASON, 1.0, 3.0, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
       REFUND_TX_INFO);
     Feefineaction refundAction2 = createAction(1, account1, "2020-01-04 12:00:00",
       REFUNDED_PARTIALLY, REFUND_REASON, 1.1, 4.1, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
       REFUND_TX_INFO);
-    Feefineaction refundAction3 = createAction(1, account1, "2020-02-01 12:00:00",
+    createAction(1, account1, "2020-02-01 12:00:00",
       REFUNDED_PARTIALLY, REFUND_REASON, 1.2, 5.3, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
       REFUND_TX_INFO);
 

--- a/src/test/java/org/folio/rest/impl/RefundReportTest.java
+++ b/src/test/java/org/folio/rest/impl/RefundReportTest.java
@@ -623,6 +623,29 @@ public class RefundReportTest extends FeeFineReportsAPITestBase {
     ));
   }
 
+  @Test
+  public void shouldSucceedWhenRefundsOfSameAccountAreBothInsideAndOutsideOfTheInterval() {
+    Account account1 = charge(USER_ID_1, 10.0, "ff-type-1", item1.getId(), OWNER_ID_1);
+    createAction(1, account1, "2020-01-03 12:00:00", PAID_PARTIALLY, PAYMENT_METHOD,
+      8.0, 2.0, PAYMENT_STAFF_INFO, PAYMENT_PATRON_INFO, PAYMENT_TX_INFO);
+    Feefineaction refundAction1 = createAction(1, account1, "2019-12-30 12:00:00",
+      REFUNDED_PARTIALLY, REFUND_REASON, 1.0, 3.0, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
+      REFUND_TX_INFO);
+    Feefineaction refundAction2 = createAction(1, account1, "2020-01-04 12:00:00",
+      REFUNDED_PARTIALLY, REFUND_REASON, 1.1, 4.1, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
+      REFUND_TX_INFO);
+    Feefineaction refundAction3 = createAction(1, account1, "2020-02-01 12:00:00",
+      REFUNDED_PARTIALLY, REFUND_REASON, 1.2, 5.3, REFUND_STAFF_INFO, REFUND_PATRON_INFO,
+      REFUND_TX_INFO);
+
+    List<RefundReportEntry> refundReportEntries = List.of(
+      buildRefundReportEntry(account1, refundAction2, "8.00", PAYMENT_METHOD, SEE_FEE_FINE_PAGE,
+        "0.00", "", addSuffix(REFUND_STAFF_INFO, 1), addSuffix(REFUND_PATRON_INFO, 1),
+        item1.getBarcode(), instance.getTitle(), FEE_FINE_OWNER));
+
+    requestAndCheck(refundReportEntries, List.of(OWNER_ID_1));
+  }
+
   private void requestAndCheck(List<RefundReportEntry> reportEntries) {
     requestAndCheck(reportEntries, null);
   }


### PR DESCRIPTION
Resolves [MODFEE-249](https://issues.folio.org/browse/MODFEE-249)

Fixes Refund report for cases when there are refunds linked to same same account both inside and outside of the requested interval