### PR TITLE
MODFEE-270: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -8,15 +8,15 @@
     },
     {
       "id": "holdings-storage",
-      "version": "4.2 5.0"
+      "version": "4.2 5.0 6.0"
     },
     {
       "id": "item-storage",
-      "version": "8.4 9.0"
+      "version": "8.4 9.0 10.0"
     },
     {
       "id": "instance-storage",
-      "version": "7.4 8.0"
+      "version": "7.4 8.0 9.0"
     },
     {
       "id": "locations",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-feesfines is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-feesfines. Changed APIs:
DELETE /inventory/instances
DELETE /inventory/items
DELETE /instance-storage/instances
DELETE /holdings-storage/holdings
DELETE /item-storage/items

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json to support the new major versions.