### PR TITLE
[MODFEE-275] Add processId field to account schema

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -50,7 +50,7 @@
   "provides":[
     {
       "id":"feesfines",
-      "version":"17.3",
+      "version":"17.4",
       "handlers":[
         {
           "methods":[

--- a/ramls/accountdata.json
+++ b/ramls/accountdata.json
@@ -174,6 +174,10 @@
     "lostItemFeePolicyId": {
       "description": "Lost item fee policy ID",
       "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "processId": {
+      "description": "Randomly generated UUID added to fees/fines created in scope of the same process (e.g. same check-in or same scheduled Lost Item Fee generation job run)",
+      "$ref": "raml-util/schemas/uuid.schema"
     }
   },
   "additionalProperties": false,

--- a/ramls/examples/account.sample
+++ b/ramls/examples/account.sample
@@ -34,5 +34,6 @@
   "id": "0bab56e5-1ab6-4ac2-afdf-8b2df0434379",
   "loanPolicyId": "f5b3ea0e-7c62-4f73-bbe5-ea8eae37c615",
   "overdueFinePolicyId": "f6f6aa71-33de-4af8-a066-2d29756f2e26",
-  "lostItemFeePolicyId": "952967a2-ce04-4eb8-a47c-e003ca6d4c31"
+  "lostItemFeePolicyId": "952967a2-ce04-4eb8-a47c-e003ca6d4c31",
+  "processId": "2294ddf3-9a30-4efd-a0a4-b2743915944f"
 }


### PR DESCRIPTION
## Purpose

- Add new optional field "processId" to fee/fine ("account") schema

Resolves: [MODFEE-275](https://issues.folio.org/browse/MODFEE-275)