### PR TITLE
MODFEE-299: RMB 35.0.2, Vert.x 4.3.4, mod-pubsub-client 2.7.0, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <powermock.version>2.0.7</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version>
-    <vertx.version>4.3.3</vertx.version>
+    <raml-module-builder.version>35.0.2</raml-module-builder.version>
+    <vertx.version>4.3.4</vertx.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>
     <!-- Postgres port for Jenkins CI build environment https://issues.folio.org/browse/METADATA-10 -->
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.3.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>3.8.6</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/test/java/org/folio/migration/FeeFineTypesDefaultReferenceRecordsTest.java
+++ b/src/test/java/org/folio/migration/FeeFineTypesDefaultReferenceRecordsTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.Vertx;
 
 public class FeeFineTypesDefaultReferenceRecordsTest extends ApiTests {
-  private static final String LOST_FEE_FOR_ACTUAL_COST_ID = "73785370-d3bd-4d92-942d-ae2268e02ded";
   private static final String MIGRATION_SCRIPT = loadMigrationScript();
 
   @Test

--- a/src/test/java/org/folio/test/support/ApiTests.java
+++ b/src/test/java/org/folio/test/support/ApiTests.java
@@ -29,8 +29,6 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
@@ -76,6 +74,7 @@ public class ApiTests {
   public static final String OKAPI_TOKEN = generateOkapiToken();
   public static final String MODULE_NAME = "mod-feesfines";
   public static final String FEEFINES_TABLE = "feefines";
+  public static final String LOST_FEE_FOR_ACTUAL_COST_ID = "73785370-d3bd-4d92-942d-ae2268e02ded";
   public static final String OWNERS_TABLE = "owners";
   public static final OkapiDeployment okapiDeployment = new OkapiDeployment();
 
@@ -166,8 +165,9 @@ public class ApiTests {
     Criterion criterion = new Criterion();
     if (FEEFINES_TABLE.equals(tableName)) {
       for (AutomaticFeeFineType type : AutomaticFeeFineType.values()) {
-        criterion.addCriterion(createAutomaticFeeFineExclusionCriteria(type), "AND");
+        criterion.addCriterion(createFeeFineExclusionCriteria(type.getId()), "AND");
       }
+      criterion.addCriterion(createFeeFineExclusionCriteria(LOST_FEE_FOR_ACTUAL_COST_ID), "AND");
     }
     PostgresClient.getInstance(vertx, TENANT_NAME)
       .delete(tableName, criterion, result -> future.complete(null));
@@ -175,11 +175,11 @@ public class ApiTests {
     get(future);
   }
 
-  private Criteria createAutomaticFeeFineExclusionCriteria(AutomaticFeeFineType automaticFeeFineType) {
+  private static Criteria createFeeFineExclusionCriteria(String id) {
     return new Criteria()
-      .addField("id")
+      .addField("'id'")
       .setOperation("!=")
-      .setVal(automaticFeeFineType.getId());
+      .setVal(id);
   }
 
   private static String generateOkapiToken() {


### PR DESCRIPTION
Upgrade mod-pubsub-client from 2.3.0 to 2.7.0.

The mod-pubsub-client upgrade indirectly upgrades spring-beans from 5.2.8.RELEASE to 5.3.20. This fixes Spring4Shell Remote Code Execution vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-22965
Note that Open Source Spring 5.2.* has been out of support since 2021-12-31:
https://spring.io/projects/spring-framework#support

The mod-pubsub-client upgrade removes the JDBC postgresql driver at version 42.2.18 that has a Remote Code Execution vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-21724

The mod-pubsub-client upgrade removes the scala-library dependency at version 2.13.1 that has a Remote Code Execution vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Upgrade RMB from 35.0.0 to 35.0.2 and Vert.x from 4.3.3 to 4.3.4. This indirectly upgrades jackson-databind from 2.13.2.1 to 2.13.4 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade maven-model from 3.3.9 to 3.8.6. This indirectly upgrades plexus-utils from 3.0.22 to 3.3.1 fixing Directory Traversal and XML External Entity (XXE) Injection:
https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521
https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102