### PR TITLE
MODFEE-298 Create an endpoint for not billing the patron for the actual cost of a lost item

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -50,7 +50,7 @@
   "provides":[
     {
       "id":"feesfines",
-      "version":"17.4",
+      "version":"17.5",
       "handlers":[
         {
           "methods":[
@@ -906,6 +906,18 @@
           "pathPattern":"/manual-block-templates/{id}",
           "permissionsRequired":[
             "manual-block-templates.item.delete"
+          ]
+        },
+        {
+          "methods":[
+            "POST"
+          ],
+          "pathPattern":"/do-not-bill-actual-cost-lost-item-fee",
+          "permissionsRequired":[
+            "do-not-bill-actual-cost-lost-item-fee.post"
+          ],
+          "modulePermissions": [
+            "actual-cost-record-storage.actual-cost-records.item.put"
           ]
         }
       ]

--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Actual cost record",
+  "properties": {
+    "id": {
+      "description": "Actual cost record ID",
+      "type": "string",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "lossType": {
+      "description": "Type of the item loss",
+      "type": "string",
+      "enum": [
+        "Aged to lost",
+        "Declared lost"
+      ]
+    },
+    "lossDate": {
+      "description": "Date and time when the item was lost",
+      "type": "string",
+      "format": "date-time"
+    },
+    "expirationDate": {
+      "description": "Expiration date and time of actual cost record",
+      "type": "string",
+      "format": "date-time"
+    },
+    "user": {
+      "description": "User info",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordUser",
+      "properties": {
+        "id": {
+          "description": "User ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "barcode": {
+          "description": "User barcode",
+          "type": "string"
+        },
+        "firstName": {
+          "description": "User first name",
+          "type": "string"
+        },
+        "lastName": {
+          "description": "User last name",
+          "type": "string"
+        },
+        "middleName": {
+          "description": "User middle name",
+          "type": "string"
+        },
+        "patronGroupId": {
+          "description": "Patron group ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "patronGroup": {
+          "description": "Patron group name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "lastName"
+      ]
+    },
+    "loan": {
+      "description": "Loan info",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordLoan",
+      "properties": {
+        "id": {
+          "description": "Loan ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "item": {
+      "description": "Item info",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordItem",
+      "properties": {
+        "id": {
+          "description": "Item ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "barcode": {
+          "description": "Item barcode",
+          "type": "string"
+        },
+        "materialTypeId": {
+          "description": "Material type ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "materialType": {
+          "description": "Material type name",
+          "type": "string"
+        },
+        "permanentLocationId": {
+          "description": "Permanent location ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "permanentLocation": {
+          "description": "Permanent location name",
+          "type": "string"
+        },
+        "loanTypeId": {
+          "description": "Loan type ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "loanType": {
+          "description": "Loan type name",
+          "type": "string"
+        },
+        "holdingsRecordId": {
+          "description": "Holdings record ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "effectiveCallNumberComponents": {
+          "type": "object",
+          "description": "Elements of a full call number generated from the item or holding",
+          "properties": {
+            "callNumber": {
+              "type": "string",
+              "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item."
+            },
+            "prefix": {
+              "type": "string",
+              "description": "Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item."
+            },
+            "suffix": {
+              "type": "string",
+              "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item."
+            }
+          },
+          "additionalProperties": false
+        },
+        "volume": {
+          "type": "string",
+          "description": "Volume is intended for monographs when a multipart monograph (e.g. a biography of George Bernard Shaw in three volumes)."
+        },
+        "enumeration": {
+          "type": "string",
+          "description": "Enumeration is the descriptive information for the numbering scheme of a serial."
+        },
+        "chronology": {
+          "type": "string",
+          "description": "Chronology is the descriptive information for the dating scheme of a serial."
+        },
+        "copyNumber": {
+          "type": "string",
+          "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; one copy of a multi-volume, (e.g. Copy 1, or C.7.)"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "materialTypeId",
+        "materialType",
+        "loanTypeId",
+        "loanType",
+        "holdingsRecordId"
+      ]
+    },
+    "instance": {
+      "description": "Instance info",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordInstance",
+      "properties": {
+        "id": {
+          "description": "Instance ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "title": {
+          "description": "Instance title",
+          "type": "string"
+        },
+        "identifiers": {
+          "type": "array",
+          "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordIdentifier",
+            "properties": {
+              "value": {
+                "type": "string",
+                "description": "Resource identifier value"
+              },
+              "identifierType": {
+                "type": "string",
+                "description": "Name of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)"
+              },
+              "identifierTypeId": {
+                "type": "string",
+                "description": "UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)",
+                "$ref": "raml-util/schemas/uuid.schema"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "value",
+              "identifierType",
+              "identifierTypeId"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title"
+      ]
+    },
+    "feeFine": {
+      "description": "Fee/fine info",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.ActualCostRecordFeeFine",
+      "properties": {
+        "accountId": {
+          "description": "ID of the fee/fine (\"account\") instance",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "ownerId": {
+          "description": "Fee/fine owner ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "owner": {
+          "description": "Fee/fine owner name",
+          "type": "string"
+        },
+        "typeId": {
+          "description": "Fee/fine type ID",
+          "type": "string",
+          "$ref": "raml-util/schemas/uuid.schema"
+        },
+        "type": {
+          "description": "Fee/fine type name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "ownerId",
+        "owner",
+        "typeId",
+        "type"
+      ]
+    },
+    "status": {
+      "description": "Status of the actual cost record",
+      "type": "string",
+      "enum": [
+        "Open",
+        "Billed",
+        "Cancelled",
+        "Expired"
+      ],
+      "default": "Open"
+    },
+    "additionalInfoForStaff": {
+      "description": "Additional information for staff",
+      "type": "string"
+    },
+    "additionalInfoForPatron": {
+      "description": "Additional information for a patron",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "lossType",
+    "lossDate",
+    "expirationDate",
+    "user",
+    "loan",
+    "item",
+    "instance",
+    "feeFine",
+    "status"
+  ]
+}

--- a/ramls/actual-cost-records.json
+++ b/ramls/actual-cost-records.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of Actual cost records",
+  "type": "object",
+  "properties": {
+    "actualCostRecords": {
+      "description": "List of Actual cost records",
+      "id": "actualCostRecords",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "actual-cost-record.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "actualCostRecords",
+    "totalRecords"
+  ]
+}
+

--- a/ramls/do-not-bill-actual-cost-lost-item-fee.json
+++ b/ramls/do-not-bill-actual-cost-lost-item-fee.json
@@ -1,0 +1,24 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title": "Do not bill actual cost of lost item schema",
+  "description": "Actual cost record for lost item fee should not be billed (cancelled)",
+  "type": "object",
+  "properties": {
+    "actualCostRecordId": {
+      "description": "Actual Cost Record ID",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "additionalInfoForStaff": {
+      "description": "Additional information for staff",
+      "type": "string"
+    },
+    "additionalInfoForPatron": {
+      "description": "Additional information for a patron",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "actualCostRecordId"
+   ]
+}

--- a/ramls/do-not-bill-actual-cost-lost-item-fee.raml
+++ b/ramls/do-not-bill-actual-cost-lost-item-fee.raml
@@ -1,0 +1,43 @@
+#%RAML 1.0
+title: Do not bill actual cost of lost item
+version: v17.3
+baseUri: http://github.com/org/folio/mod-feesfines
+
+documentation:
+  - title: Do Not Bill Actual Cost Record Lost Item Fee API
+    content: This documents the API calls to not bill actual cost
+
+types:
+  doNotBillActualCost: !include do-not-bill-actual-cost-lost-item-fee.json
+  actualCostRecord: !include actual-cost-record.json
+  actualCostRecords: !include actual-cost-records.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
+
+/do-not-bill-actual-cost-lost-item-fee:
+  post:
+    is: [validate]
+    description: "Return data for a refund report"
+    body:
+      application/json:
+        schema: doNotBillActualCost
+        example: !include examples/do-not-bill-actual-cost-lost-item-fee.sample
+    responses:
+      201:
+        body:
+          application/json:
+            schema: doNotBillActualCost
+            example: !include examples/do-not-bill-actual-cost-lost-item-fee.sample
+      422:
+        description: "Unprocessable entity"
+        body:
+          text/plain:
+            example: "Invalid actualCostRecordId"
+      500:
+        description: "Internal server error, e.g. due to misconfiguration"
+        body:
+          text/plain:
+            example: "Internal server error"

--- a/ramls/examples/actual-cost-record.json
+++ b/ramls/examples/actual-cost-record.json
@@ -1,0 +1,64 @@
+{
+  "id": "89105c06-dbdb-4aa0-9695-d4d19c733270",
+  "lossType": "Aged to lost",
+  "lossDate": "2022-01-01T22:25:37.000+00:00",
+  "expirationDate": "2022-02-01T23:59:59.000+00:00",
+  "user": {
+    "id": "88805c06-dbdb-4aa0-9695-d4d19c733221",
+    "barcode": "777",
+    "firstName": "John",
+    "lastName": "Doe",
+    "middleName": "Robert",
+    "patronGroupId": "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f",
+    "patronGroup": "librarian"
+  },
+  "loan": {
+    "id": "65de6432-be11-48ba-9686-a65101634040"
+  },
+  "item": {
+    "id": "b7bee7e9-f41d-4136-b7eb-af00c2f6d274",
+    "barcode": "123456",
+    "materialTypeId": "57a578ab-4dde-4f75-909c-edc74772d09b",
+    "materialType": "book",
+    "permanentLocationId": "9da9dcdd-474f-4e16-bb83-21e64e5eb288",
+    "permanentLocation": "Main library",
+    "loanTypeId": "e1e17294-dd52-44ae-8a94-b96aa08ef3b5",
+    "loanType": "Can circulate",
+    "holdingsRecordId": "68190dd4-9a88-4dbe-af1a-9048be222ac8",
+    "effectiveCallNumberComponents": {
+      "callNumber": "TX809.M17J66",
+      "prefix": "f",
+      "suffix": "1993"
+    },
+    "volume": "v. 2",
+    "enumeration": "v.73:no.1-6",
+    "chronology": "1985:July-Dec.",
+    "copyNumber": "c.1"
+  },
+  "instance": {
+    "id": "9dfe10e5-6db9-4f80-b574-7edc0f960288",
+    "title": "Nod",
+    "identifiers": [{
+      "value": "9781466636897",
+      "identifierType": "ISBN",
+      "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+    }
+    ]
+  },
+  "feeFine": {
+    "accountId": "306339a5-539b-4652-be7c-ab041a286c8c",
+    "ownerId": "a2e1729a-2593-4a2a-8069-2fee39d9ae31",
+    "owner": "Default owner",
+    "typeId": "92ef9706-f1af-430d-9edd-78035689efa2",
+    "type": "Overdue fine"
+  },
+  "status": "Billed",
+  "additionalInformationForStaff": "Additional information for staff",
+  "additionalInformationForPatron": "Additional information for a patron",
+  "metadata": {
+    "createdDate": "2022-09-19T14:09:41.284+00:00",
+    "createdByUserId": "5bcadcf1-2608-4cd3-b4e2-947ffe58d15f",
+    "updatedDate": "2022-09-19T14:09:41.284+00:00",
+    "updatedByUserId": "5bcadcf1-2608-4cd3-b4e2-947ffe58d15f"
+  }
+}

--- a/ramls/examples/actual-cost-records.json
+++ b/ramls/examples/actual-cost-records.json
@@ -1,0 +1,61 @@
+{
+  "actualCostRecords" : [
+    {
+      "id": "89105c06-dbdb-4aa0-9695-d4d19c733270",
+      "lossType": "Aged to lost",
+      "lossDate": "2022-01-01T22:25:37.000+00:00",
+      "expirationDate": "2022-02-01T23:59:59.000+00:00",
+      "user": {
+        "id": "88805c06-dbdb-4aa0-9695-d4d19c733221",
+        "barcode": "777",
+        "firstName": "John",
+        "lastName": "Doe",
+        "middleName": "Robert"
+      },
+      "loan": {
+        "id": "65de6432-be11-48ba-9686-a65101634040"
+      },
+      "item": {
+        "id": "b7bee7e9-f41d-4136-b7eb-af00c2f6d274",
+        "barcode": "123456",
+        "materialTypeId": "57a578ab-4dde-4f75-909c-edc74772d09b",
+        "materialType": "book",
+        "permanentLocationId": "9da9dcdd-474f-4e16-bb83-21e64e5eb288",
+        "permanentLocation": "Main library",
+        "loanTypeId": "e1e17294-dd52-44ae-8a94-b96aa08ef3b5",
+        "loanType": "Can circulate",
+        "holdingsRecordId": "68190dd4-9a88-4dbe-af1a-9048be222ac8",
+        "effectiveCallNumberComponents": {
+          "callNumber": "TX809.M17J66",
+          "prefix": "f",
+          "suffix": "1993"
+        }
+      },
+      "instance": {
+        "id": "9dfe10e5-6db9-4f80-b574-7edc0f960288",
+        "title": "Nod",
+        "identifiers": [{
+          "value": "9781466636897",
+          "identifierType": "ISBN",
+          "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+        }
+        ]
+      },
+      "feeFine": {
+        "accountId": "306339a5-539b-4652-be7c-ab041a286c8c",
+        "ownerId": "a2e1729a-2593-4a2a-8069-2fee39d9ae31",
+        "owner": "Default owner",
+        "typeId": "92ef9706-f1af-430d-9edd-78035689efa2",
+        "type": "Overdue fine"
+      },
+      "metadata": {
+        "createdDate": "2022-09-19T14:09:41.284+00:00",
+        "createdByUserId": "5bcadcf1-2608-4cd3-b4e2-947ffe58d15f",
+        "updatedDate": "2022-09-19T14:09:41.284+00:00",
+        "updatedByUserId": "5bcadcf1-2608-4cd3-b4e2-947ffe58d15f"
+      }
+    }
+
+  ],
+  "totalRecords": 1
+}

--- a/ramls/examples/do-not-bill-actual-cost-lost-item-fee.sample
+++ b/ramls/examples/do-not-bill-actual-cost-lost-item-fee.sample
@@ -1,0 +1,5 @@
+{
+  "actualCostRecordId": "1dcfc936-9402-45f2-b681-bd18d8601f6d",
+  "additionalInfoForStaff": "Additional information for staff",
+  "additionalInfoForPatron": "Additional information for a patron"
+}

--- a/src/main/java/org/folio/rest/client/ActualCostRecordClient.java
+++ b/src/main/java/org/folio/rest/client/ActualCostRecordClient.java
@@ -1,0 +1,50 @@
+package org.folio.rest.client;
+
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+
+import java.util.Map;
+
+import org.folio.rest.jaxrs.model.ActualCostRecord;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+
+public class ActualCostRecordClient extends OkapiClient {
+
+  public static final String ACTUAL_COST_RECORD_STORAGE = "/actual-cost-record-storage/actual-cost-records";
+
+  public ActualCostRecordClient(Vertx vertx, Map<String, String> okapiHeaders) {
+    super(vertx, okapiHeaders);
+  }
+
+  public Future<ActualCostRecord> fetchActualCostRecordById(String actualCostRecordId) {
+    return getById(ACTUAL_COST_RECORD_STORAGE, actualCostRecordId,
+      ActualCostRecord.class);
+  }
+
+  public Future<HttpResponse<Buffer>> updateActualCostRecord(ActualCostRecord actualCostRecord) {
+    final Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    okapiPutAbs(ACTUAL_COST_RECORD_STORAGE, actualCostRecord.getId())
+      .sendJson(actualCostRecord, response -> {
+        if (response.failed()) {
+          promise.fail(response.cause());
+        } else {
+          promise.complete(response.result());
+        }
+      });
+
+    return promise.future()
+      .compose(response -> {
+        if (response.statusCode() != HTTP_NO_CONTENT.toInt()) {
+          log.error("The actual cost record was not updated, the error code is {}, " +
+            "error message {}", response.statusCode(), response.statusMessage());
+        }
+        return Future.succeededFuture(response);
+      })
+      .recover(Future::failedFuture);
+  }
+}

--- a/src/main/java/org/folio/rest/client/OkapiClient.java
+++ b/src/main/java/org/folio/rest/client/OkapiClient.java
@@ -74,6 +74,14 @@ public class OkapiClient {
       .putHeader(OKAPI_HEADER_TOKEN, token);
   }
 
+  HttpRequest<Buffer> okapiPutAbs(String path, String id) {
+    return webClient.putAbs(okapiUrl + path + "/" + id)
+      .putHeader(ACCEPT, APPLICATION_JSON)
+      .putHeader(OKAPI_HEADER_TENANT, tenant)
+      .putHeader(OKAPI_URL_HEADER, okapiUrl)
+      .putHeader(OKAPI_HEADER_TOKEN, token);
+  }
+
   public <T> Future<T> getById(String resourcePath, String id, Class<T> objectType) {
     Optional<String> validationError = validateGetByIdArguments(resourcePath, id, objectType);
     if (validationError.isPresent()) {

--- a/src/main/java/org/folio/rest/impl/DoNotBillActualCostLostItemFeeAPI.java
+++ b/src/main/java/org/folio/rest/impl/DoNotBillActualCostLostItemFeeAPI.java
@@ -1,0 +1,31 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.DoNotBillActualCost;
+import org.folio.rest.jaxrs.resource.DoNotBillActualCostLostItemFee;
+import org.folio.rest.service.ActualCostRecordService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class DoNotBillActualCostLostItemFeeAPI implements DoNotBillActualCostLostItemFee {
+
+  @Override
+  public void postDoNotBillActualCostLostItemFee(DoNotBillActualCost entity,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    new ActualCostRecordService(vertxContext.owner(), okapiHeaders)
+      .cancelActualCostRecord(entity)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(
+        PostDoNotBillActualCostLostItemFeeResponse.respond201WithApplicationJson(entity))))
+      .onFailure(throwable -> asyncResultHandler.handle(succeededFuture(
+        PostDoNotBillActualCostLostItemFeeResponse.respond500WithTextPlain(entity))));
+  }
+}

--- a/src/main/java/org/folio/rest/service/ActualCostRecordService.java
+++ b/src/main/java/org/folio/rest/service/ActualCostRecordService.java
@@ -1,0 +1,39 @@
+package org.folio.rest.service;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Map;
+
+import org.folio.rest.client.ActualCostRecordClient;
+import org.folio.rest.jaxrs.model.ActualCostRecord;
+import org.folio.rest.jaxrs.model.DoNotBillActualCost;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+
+public class ActualCostRecordService {
+  private final ActualCostRecordClient actualCostRecordClient;
+
+  public ActualCostRecordService(Vertx vertx, Map<String, String> okapiHeaders) {
+    this.actualCostRecordClient = new ActualCostRecordClient(vertx, okapiHeaders);
+  }
+
+  public Future<HttpResponse<Buffer>> cancelActualCostRecord(DoNotBillActualCost doNotBillActualCostEntity) {
+    return actualCostRecordClient.fetchActualCostRecordById(doNotBillActualCostEntity.getActualCostRecordId())
+      .compose(actualCostRecord -> updateActualCostRecordWithCancelledStatus(
+        actualCostRecord, doNotBillActualCostEntity))
+      .compose(actualCostRecordClient::updateActualCostRecord)
+      .recover(Future::failedFuture);
+  }
+
+  private Future<ActualCostRecord> updateActualCostRecordWithCancelledStatus(
+    ActualCostRecord actualCostRecord, DoNotBillActualCost doNotBillActualCostEntity) {
+
+    return succeededFuture(actualCostRecord
+      .withStatus(ActualCostRecord.Status.CANCELLED)
+      .withAdditionalInfoForPatron(doNotBillActualCostEntity.getAdditionalInfoForPatron())
+      .withAdditionalInfoForStaff(doNotBillActualCostEntity.getAdditionalInfoForStaff()));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/DoNotBillActualCostLostItemFeeAPITest.java
+++ b/src/test/java/org/folio/rest/impl/DoNotBillActualCostLostItemFeeAPITest.java
@@ -1,0 +1,71 @@
+package org.folio.rest.impl;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.ActualCostRecord;
+import org.folio.test.support.ApiTests;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+
+public class DoNotBillActualCostLostItemFeeAPITest extends ApiTests {
+  private static final String REST_PATH = "/do-not-bill-actual-cost-lost-item-fee";
+
+  @Test
+  public void canPostDoNotBillActualCostEntity() {
+    String actualCostRecordId = randomId();
+
+    String doNotBilActualCostJson = new JsonObject()
+      .put("actualCostRecordId", actualCostRecordId)
+      .put("additionalInfoForStaff", "Test info for staff")
+      .put("additionalInfoForPatron", "Test info for patron")
+      .encodePrettily();
+
+    ActualCostRecord actualCostRecord = new ActualCostRecord()
+      .withId(actualCostRecordId)
+      .withStatus(ActualCostRecord.Status.OPEN);
+
+    createStub(format("/actual-cost-record-storage/actual-cost-records/%s", actualCostRecordId),
+      actualCostRecord);
+
+    post(doNotBilActualCostJson)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .contentType(ContentType.JSON)
+      .body(allOf(List.of(
+        hasJsonPath("actualCostRecordId", is(actualCostRecordId)),
+        hasJsonPath("additionalInfoForStaff", is("Test info for staff")),
+        hasJsonPath("additionalInfoForPatron", is("Test info for patron"))
+      )));
+  }
+
+  @Test
+  public void postDoNotBillActualCostEntityShouldFailIfRecordIsNotFound() {
+    String actualCostRecordId = randomId();
+
+    String doNotBilActualCostJson = new JsonObject()
+      .put("actualCostRecordId", actualCostRecordId)
+      .put("additionalInfoForStaff", "Test info for staff")
+      .put("additionalInfoForPatron", "Test info for patron")
+      .encodePrettily();
+
+    createStubWith404Status(format("/actual-cost-record-storage/actual-cost-records/%s",
+      actualCostRecordId));
+
+    post(doNotBilActualCostJson)
+      .then()
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  private Response post(String entity) {
+    return client.post(REST_PATH, entity);
+  }
+}

--- a/src/test/java/org/folio/rest/utils/ResourceClients.java
+++ b/src/test/java/org/folio/rest/utils/ResourceClients.java
@@ -122,6 +122,10 @@ public final class ResourceClients {
     return new ReportResourceClient("/feefine-reports/financial-transactions-detail");
   }
 
+  public static ResourceClient buildDoNotBillActualCostLostItemFeeClient() {
+    return new ResourceClient("/do-not-bill-actual-cost-lost-item-fee");
+  }
+
   public static ResourceClient tenantClient() {
     return new ResourceClient("/_/tenant");
   }

--- a/src/test/java/org/folio/test/support/ApiTests.java
+++ b/src/test/java/org/folio/test/support/ApiTests.java
@@ -270,6 +270,10 @@ public class ApiTests {
     return createStub(urlPathEqualTo(url), responseBuilder);
   }
 
+  protected StubMapping createStubWith404Status(String url) {
+    return createStub(url, aResponse().withStatus(404));
+  }
+
   private StubMapping createStubForPathMatching(String regex,
     ResponseDefinitionBuilder responseBuilder) {
 


### PR DESCRIPTION
## Purpose 
- Add new endpoint:

POST /do-not-bill-actual-cost-lost-item-fee

{
  "actualCostRecordId": "..."
}
This endpoint should:

- Set additional information (comments) in actual cost record (needs to be discussed with [Holly Mistlebauer](https://issues.folio.org/secure/ViewProfile.jspa?name=hollyolepm))
- Change actual cost record status to "Cancelled"

- add tests;

Resolves: [MODFEE-298](https://issues.folio.org/browse/MODFEE-298)