### PR TITLE
MODFEE-315 Enable UUID-validation for 'createdAt', backup invalid values

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -54,7 +54,7 @@
   "provides":[
     {
       "id":"feesfines",
-      "version":"17.4",
+      "version":"18.0",
       "handlers":[
         {
           "methods":[

--- a/ramls/feefineactiondata.json
+++ b/ramls/feefineactiondata.json
@@ -36,7 +36,11 @@
       "type": "string"
     },
     "createdAt": {
-      "description": "Location where activity took place (from login information)",
+      "description": "ID of the service point where the action was created",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "originalCreatedAt": {
+      "description": "Original invalid (non-UUID) value of 'createdAt' moved here when UUID-validation was enabled for 'createdAt'",
       "type": "string"
     },
     "source": {

--- a/src/main/resources/templates/db_scripts/rename_non_uuid_created_at.sql
+++ b/src/main/resources/templates/db_scripts/rename_non_uuid_created_at.sql
@@ -1,0 +1,4 @@
+UPDATE ${myuniversity}_${mymodule}.feefineactions
+SET jsonb = jsonb - 'createdAt' || jsonb_build_object('originalCreatedAt', jsonb->'createdAt')
+WHERE jsonb->'createdAt' IS NOT NULL
+AND jsonb->>'createdAt' !~ '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}';

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -140,6 +140,11 @@
       "run": "after",
       "snippetPath": "add-lost-fee-for-actual-cost.sql",
       "fromModuleVersion": "15.10.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "rename_non_uuid_created_at.sql",
+      "fromModuleVersion": "18.3.0"
     }
   ]
 }

--- a/src/test/java/org/folio/migration/FeeFineActionMigrationTest.java
+++ b/src/test/java/org/folio/migration/FeeFineActionMigrationTest.java
@@ -1,0 +1,126 @@
+package org.folio.migration;
+
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.folio.rest.utils.ResourceClients.buildFeeFineActionsClient;
+import static org.folio.util.PomUtils.getModuleId;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Date;
+import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.domain.MonetaryValue;
+import org.folio.rest.jaxrs.model.Feefineaction;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.utils.ResourceClient;
+import org.folio.test.support.ApiTests;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FeeFineActionMigrationTest extends ApiTests {
+
+  private static final String CREATED_AT_KEY = "createdAt";
+  private static final String ORIGINAL_CREATED_AT_KEY = "originalCreatedAt";
+  private static final String FEE_FINE_ACTIONS_TABLE = "feefineactions";
+  private static final String OLDER_VERSION = "mod-feesfines-18.2.0";
+  private static final String MIGRATION_VERSION = "mod-feesfines-18.3.0";
+
+  private final ResourceClient feeFineActionsClient = buildFeeFineActionsClient();
+
+  @BeforeEach
+  void beforeEach() {
+    // Module was enabled in @BeforeAll with 'module_to' equal to current module version from POM.
+    // We must downgrade to lower version first if we want to rerun the migration script (see RMB-937)
+    postTenant(getModuleId(), OLDER_VERSION);
+  }
+
+  @AfterEach
+  void afterEach() {
+    removeAllFromTable(FEE_FINE_ACTIONS_TABLE);
+  }
+
+  @Test
+  void migrationIsSuccessfulWhenNoInvalidActionsAreFound() {
+    Response response = postTenant(OLDER_VERSION, MIGRATION_VERSION);
+    assertThat(response.getStatus(), is(SC_NO_CONTENT));
+  }
+
+  @Test
+  void actionIsNotUpdatedWhenWhenItDoesNotHaveCreatedAt() {
+    String actionId = createAction(null);
+    Response response = postTenant(OLDER_VERSION, MIGRATION_VERSION);
+    assertThat(response.getStatus(), is(SC_NO_CONTENT));
+    verifyKeyValue(actionId, CREATED_AT_KEY, nullValue());
+    verifyKeyValue(actionId, ORIGINAL_CREATED_AT_KEY, nullValue());
+  }
+
+  @Test
+  void actionIsNotUpdatedWhenItAlreadyContainsValidCreatedAtValue() {
+    String uuid = randomId();
+    String actionId = createAction(uuid);
+    Response response = postTenant(OLDER_VERSION, MIGRATION_VERSION);
+    assertThat(response.getStatus(), is(SC_NO_CONTENT));
+    verifyKeyValue(actionId, CREATED_AT_KEY, uuid);
+    verifyKeyValue(actionId, ORIGINAL_CREATED_AT_KEY, nullValue());
+  }
+
+  @Test
+  void actionIsUpdatedWhenCreatedAtContainsNonUuidValue() {
+    String createdAt = "not-a-uuid";
+    String actionId = createAction(createdAt);
+    Response response = postTenant(OLDER_VERSION, MIGRATION_VERSION);
+    assertThat(response.getStatus(), is(SC_NO_CONTENT));
+    verifyKeyValue(actionId, CREATED_AT_KEY, nullValue());
+    verifyKeyValue(actionId, ORIGINAL_CREATED_AT_KEY, createdAt);
+  }
+
+  private static Feefineaction buildAction(String createdAt) {
+    return new Feefineaction()
+      .withId(randomId())
+      .withTypeAction("Test action type")
+      .withAmountAction(new MonetaryValue(1.0))
+      .withUserId(randomId())
+      .withDateAction(new Date())
+      .withAccountId(randomId())
+      .withBalance(new MonetaryValue(1.0))
+      .withPaymentMethod("Cash")
+      .withSource("test")
+      .withNotify(false)
+      .withTransactionInformation("-")
+      .withCreatedAt(createdAt);
+  }
+
+  private static Response postTenant(String moduleFrom, String moduleTo) {
+    TenantAttributes tenantAttributes = getTenantAttributes()
+      .withModuleFrom(moduleFrom)
+      .withModuleTo(moduleTo);
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    createTenant(tenantAttributes, future);
+
+    return get(future);
+  }
+  
+  private String createAction(String createdAt) {
+    Feefineaction action = buildAction(createdAt);
+    get(pgClient.save(FEE_FINE_ACTIONS_TABLE, action.getId(), action));
+    
+    return action.getId();
+  }
+
+  private void verifyKeyValue(String actionId, String key, String value) {
+    verifyKeyValue(actionId, key, is(value));
+  }
+
+  private void verifyKeyValue(String actionId, String key, Matcher<Object> valueMatcher) {
+    feeFineActionsClient.getById(actionId)
+      .then()
+      .body(key, valueMatcher);
+  }
+
+}

--- a/src/test/java/org/folio/migration/FeeFineTypesDefaultReferenceRecordsTest.java
+++ b/src/test/java/org/folio/migration/FeeFineTypesDefaultReferenceRecordsTest.java
@@ -7,6 +7,9 @@ import static org.hamcrest.Matchers.is;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+
+import javax.ws.rs.core.Response;
+
 import org.folio.rest.domain.AutomaticFeeFineType;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.test.support.ApiTests;
@@ -39,7 +42,7 @@ public class FeeFineTypesDefaultReferenceRecordsTest extends ApiTests {
       .withModuleFrom(MODULE_NAME + "-" + moduleFromVersion)
       .withModuleTo(MODULE_NAME + "-" + moduleToVersion);
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Response> future = new CompletableFuture<>();
     createTenant(tenantAttributes, future);
     get(future);
   }


### PR DESCRIPTION
- only allow UUIDs in property `createdAt` of fee/fine action
- copy existing invalid (non-UUID) values into new field `originalCreatedAt`, remove `createdAt` key from affected actions afterwards

Resolves [MODFEE-315](https://issues.folio.org/browse/MODFEE-315)