### PR TITLE
MODFEE-327 Add error handling for invalid configuration

### DIFF
--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -70,7 +70,7 @@ public class ConfigurationClient extends OkapiClient {
             ));
           }
         } catch (Exception e) {
-          log.error("Failed to parse response: " + response.bodyAsString());
+          log.error("Failed to parse response: {}", response.bodyAsString(), e);
           return failedFuture(e);
         }
       }

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -28,9 +28,6 @@ import io.vertx.ext.web.client.HttpResponse;
 public class ConfigurationClient extends OkapiClient {
   private static final Logger log = LogManager.getLogger(ConfigurationClient.class);
 
-  private static final DateTimeZone DEFAULT_DATE_TIME_ZONE = DateTimeZone.UTC;
-  private static final String TIMEZONE_KEY = "timezone";
-
   public ConfigurationClient(Vertx vertx, Map<String, String> okapiHeaders) {
     super(vertx, okapiHeaders);
   }
@@ -72,7 +69,7 @@ public class ConfigurationClient extends OkapiClient {
               localeSettingsJsonObject.getString("currency")
             ));
           }
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
           log.error("Failed to parse response: " + response.bodyAsString());
           return failedFuture(e);
         }

--- a/src/main/java/org/folio/rest/domain/LocaleSettings.java
+++ b/src/main/java/org/folio/rest/domain/LocaleSettings.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTimeZone;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NonNull;
 
 @AllArgsConstructor
 @Getter
@@ -13,6 +14,7 @@ public class LocaleSettings {
 
   private final String locale;
   private final String timezone;
+  @NonNull
   private final String currency;
 
   public DateTimeZone getDateTimeZone() {

--- a/src/test/java/org/folio/rest/impl/CashDrawerReconciliationReportTest.java
+++ b/src/test/java/org/folio/rest/impl/CashDrawerReconciliationReportTest.java
@@ -81,6 +81,13 @@ public class CashDrawerReconciliationReportTest extends FeeFineReportsAPITestBas
   }
 
   @Test
+  public void okResponseWhenLocaleConfigDoesNotHaveCurrency() {
+    removeLocaleSettingsStub();
+    createLocaleSettingsStubWithoutCurrency();
+    requestAndCheck(emptyReport());
+  }
+
+  @Test
   public void okResponseWhenLocaleConfigExists() {
     requestAndCheck(emptyReport());
   }

--- a/src/test/java/org/folio/rest/impl/FeeFineReportsAPITestBase.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineReportsAPITestBase.java
@@ -2,7 +2,6 @@ package org.folio.rest.impl;
 
 import static java.lang.String.format;
 import static org.folio.test.support.EntityBuilder.buildLocaleSettingsConfigurations;
-import static org.folio.test.support.EntityBuilder.buildLocaleSettingsConfigurationsWithoutCurrency;
 import static org.folio.test.support.matcher.constant.ServicePath.ACCOUNTS_PATH;
 
 import java.util.Date;
@@ -56,14 +55,15 @@ public class FeeFineReportsAPITestBase extends ApiTests {
   }
 
   void createLocaleSettingsStub() {
-    final KvConfigurations localeSettingsConfigurations = buildLocaleSettingsConfigurations();
+    final KvConfigurations localeSettingsConfigurations = buildLocaleSettingsConfigurations(
+      "{\"locale\":\"en-US\",\"timezone\":\"America/New_York\",\"currency\":\"USD\"}");
     localeSettingsStubMapping = createStubForPath(ServicePath.CONFIGURATION_ENTRIES,
       localeSettingsConfigurations, ".*");
   }
 
   void createLocaleSettingsStubWithoutCurrency() {
     localeSettingsStubMapping = createStubForPath(ServicePath.CONFIGURATION_ENTRIES,
-      buildLocaleSettingsConfigurationsWithoutCurrency(), ".*");
+      buildLocaleSettingsConfigurations("{\"locale\":\"en-US\",\"timezone\":\"America/New_York\"}"), ".*");
   }
 
   void removeLocaleSettingsStub() {

--- a/src/test/java/org/folio/rest/impl/FeeFineReportsAPITestBase.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineReportsAPITestBase.java
@@ -2,9 +2,7 @@ package org.folio.rest.impl;
 
 import static java.lang.String.format;
 import static org.folio.test.support.EntityBuilder.buildLocaleSettingsConfigurations;
-import static org.folio.test.support.matcher.constant.DbTable.ACCOUNTS_TABLE;
-import static org.folio.test.support.matcher.constant.DbTable.FEEFINES_TABLE;
-import static org.folio.test.support.matcher.constant.DbTable.FEE_FINE_ACTIONS_TABLE;
+import static org.folio.test.support.EntityBuilder.buildLocaleSettingsConfigurationsWithoutCurrency;
 import static org.folio.test.support.matcher.constant.ServicePath.ACCOUNTS_PATH;
 
 import java.util.Date;
@@ -61,6 +59,11 @@ public class FeeFineReportsAPITestBase extends ApiTests {
     final KvConfigurations localeSettingsConfigurations = buildLocaleSettingsConfigurations();
     localeSettingsStubMapping = createStubForPath(ServicePath.CONFIGURATION_ENTRIES,
       localeSettingsConfigurations, ".*");
+  }
+
+  void createLocaleSettingsStubWithoutCurrency() {
+    localeSettingsStubMapping = createStubForPath(ServicePath.CONFIGURATION_ENTRIES,
+      buildLocaleSettingsConfigurationsWithoutCurrency(), ".*");
   }
 
   void removeLocaleSettingsStub() {

--- a/src/test/java/org/folio/rest/impl/FinancialTransactionDetailReportTest.java
+++ b/src/test/java/org/folio/rest/impl/FinancialTransactionDetailReportTest.java
@@ -218,6 +218,13 @@ public class FinancialTransactionDetailReportTest extends FeeFineReportsAPITestB
   }
 
   @Test
+  public void okResponseWhenLocaleConfigDoesNotHaveCurrency() {
+    removeLocaleSettingsStub();
+    createLocaleSettingsStubWithoutCurrency();
+    requestAndCheck(emptyReport());
+  }
+
+  @Test
   public void okResponseWhenLocaleConfigExists() {
     requestAndCheck(emptyReport());
   }

--- a/src/test/java/org/folio/rest/impl/RefundReportTest.java
+++ b/src/test/java/org/folio/rest/impl/RefundReportTest.java
@@ -148,6 +148,13 @@ public class RefundReportTest extends FeeFineReportsAPITestBase {
   }
 
   @Test
+  public void okResponseWhenLocaleConfigDoesNotHaveCurrency() {
+    removeLocaleSettingsStub();
+    createLocaleSettingsStubWithoutCurrency();
+    requestAndCheck(List.of());
+  }
+
+  @Test
   public void okResponseWhenLocaleConfigExists() {
     requestAndCheck(List.of());
   }

--- a/src/test/java/org/folio/test/support/EntityBuilder.java
+++ b/src/test/java/org/folio/test/support/EntityBuilder.java
@@ -244,27 +244,14 @@ public class EntityBuilder {
       .withAdditionalProperty(KEY_NAME, "Institution");
   }
 
-  public static KvConfigurations buildLocaleSettingsConfigurations() {
+  public static KvConfigurations buildLocaleSettingsConfigurations(String value) {
     return new KvConfigurations()
       .withConfigs(List.of(new Config()
         .withId(randomId())
         .withModule("ORG")
         .withConfigName("localeSettings")
         .withEnabled(true)
-        .withValue(
-          "{\"locale\":\"en-US\",\"timezone\":\"America/New_York\",\"currency\":\"USD\"}")))
-      .withTotalRecords(1);
-  }
-
-  public static KvConfigurations buildLocaleSettingsConfigurationsWithoutCurrency() {
-    return new KvConfigurations()
-      .withConfigs(List.of(new Config()
-        .withId(randomId())
-        .withModule("ORG")
-        .withConfigName("localeSettings")
-        .withEnabled(true)
-        .withValue(
-          "{\"locale\":\"en-US\",\"timezone\":\"America/New_York\"}")))
+        .withValue(value)))
       .withTotalRecords(1);
   }
 

--- a/src/test/java/org/folio/test/support/EntityBuilder.java
+++ b/src/test/java/org/folio/test/support/EntityBuilder.java
@@ -256,6 +256,18 @@ public class EntityBuilder {
       .withTotalRecords(1);
   }
 
+  public static KvConfigurations buildLocaleSettingsConfigurationsWithoutCurrency() {
+    return new KvConfigurations()
+      .withConfigs(List.of(new Config()
+        .withId(randomId())
+        .withModule("ORG")
+        .withConfigName("localeSettings")
+        .withEnabled(true)
+        .withValue(
+          "{\"locale\":\"en-US\",\"timezone\":\"America/New_York\"}")))
+      .withTotalRecords(1);
+  }
+
   public static Loan buildLoan(String loanDate, Date dueDate, String returnDate, String itemId,
     String loanPolicyId, String overdueFinePolicyId, String lostItemPolicyId) {
 


### PR DESCRIPTION
## Purpose
- Fix the issue with inability to generate Financial Transaction Detail Report, Cash Drawer Reconciliation Report, and Refunds to Process Manually Report in Orchid Bugfest;

Resolves: [MODFEE-327](https://issues.folio.org/browse/MODFEE-327)
## Approach
- fail configuration parsing if it's not correct;
- use the default configuration for this kind of scenario;
- add tests to cover this scenario for each report;