### PR TITLE
MODFEE-328 Add the field "effectiveLocationDiscoveryDisplayName" to the Item Object in the Notice context

### DIFF
--- a/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
+++ b/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
@@ -123,6 +123,7 @@ public class PatronNoticeBuilder {
 
     if (location != null) {
       itemContext.put(EFFECTIVE_LOCATION_SPECIFIC, location.getName());
+      itemContext.put("effectiveLocationDiscoveryDisplayName", location.getDiscoveryDisplayName());
 
       if (location.getLibrary() != null) {
         itemContext.put("effectiveLocationLibrary",

--- a/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
+++ b/src/main/java/org/folio/rest/utils/PatronNoticeBuilder.java
@@ -38,6 +38,7 @@ public class PatronNoticeBuilder {
   public static final String TITLE = "title";
   public static final String CALL_NUMBER = "callNumber";
   public static final String EFFECTIVE_LOCATION_SPECIFIC = "effectiveLocationSpecific";
+  public static final String EFFECTIVE_LOCATION_DISCOVERY_DISPLAY_NAME = "effectiveLocationDiscoveryDisplayName";
 
   private PatronNoticeBuilder() {
     throw new UnsupportedOperationException("Utility class");
@@ -123,7 +124,7 @@ public class PatronNoticeBuilder {
 
     if (location != null) {
       itemContext.put(EFFECTIVE_LOCATION_SPECIFIC, location.getName());
-      itemContext.put("effectiveLocationDiscoveryDisplayName", location.getDiscoveryDisplayName());
+      itemContext.put(EFFECTIVE_LOCATION_DISCOVERY_DISPLAY_NAME, location.getDiscoveryDisplayName());
 
       if (location.getLibrary() != null) {
         itemContext.put("effectiveLocationLibrary",

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -345,6 +345,7 @@ public class FeeFineActionsAPITest extends ApiTests {
           .put("primaryContributor", PRIMARY_CONTRIBUTOR_NAME)
           .put("allContributors", PRIMARY_CONTRIBUTOR_NAME + "; " + NON_PRIMARY_CONTRIBUTOR_NAME)
           .put("effectiveLocationSpecific", location.getName())
+          .put("effectiveLocationDiscoveryDisplayName",location.getDiscoveryDisplayName())
           .put("effectiveLocationLibrary", getNameFromProperties(library.getAdditionalProperties()))
           .put("effectiveLocationInstitution", getNameFromProperties(institution.getAdditionalProperties()))
           .put("effectiveLocationCampus", getNameFromProperties(campus.getAdditionalProperties()))

--- a/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/FeeFineActionsAPITest.java
@@ -345,7 +345,7 @@ public class FeeFineActionsAPITest extends ApiTests {
           .put("primaryContributor", PRIMARY_CONTRIBUTOR_NAME)
           .put("allContributors", PRIMARY_CONTRIBUTOR_NAME + "; " + NON_PRIMARY_CONTRIBUTOR_NAME)
           .put("effectiveLocationSpecific", location.getName())
-          .put("effectiveLocationDiscoveryDisplayName",location.getDiscoveryDisplayName())
+          .put("effectiveLocationDiscoveryDisplayName", location.getDiscoveryDisplayName())
           .put("effectiveLocationLibrary", getNameFromProperties(library.getAdditionalProperties()))
           .put("effectiveLocationInstitution", getNameFromProperties(institution.getAdditionalProperties()))
           .put("effectiveLocationCampus", getNameFromProperties(campus.getAdditionalProperties()))

--- a/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
+++ b/src/test/java/org/folio/rest/utils/PatronNoticeBuilderTest.java
@@ -127,6 +127,7 @@ public class PatronNoticeBuilderTest {
       itemContext.getString("allContributors"));
 
     assertEquals(location.getName(), itemContext.getString("effectiveLocationSpecific"));
+    assertEquals(location.getDiscoveryDisplayName(), itemContext.getString("effectiveLocationDiscoveryDisplayName"));
     assertEquals(location.getLibrary().getAdditionalProperties().get(NAME),
       itemContext.getString("effectiveLocationLibrary"));
     assertEquals(location.getInstitution().getAdditionalProperties().get(NAME),
@@ -291,6 +292,7 @@ public class PatronNoticeBuilderTest {
   private static Location createLocation() {
     return new Location()
       .withName("Specific")
+      .withDiscoveryDisplayName("DiscoveryDisplayName")
       .withLibrary(new Library().withAdditionalProperty(NAME, "Library"))
       .withInstitution(new Institution().withAdditionalProperty(NAME, "Institution"))
       .withCampus(new Campus().withAdditionalProperty(NAME, "Campus"));

--- a/src/test/java/org/folio/test/support/EntityBuilder.java
+++ b/src/test/java/org/folio/test/support/EntityBuilder.java
@@ -223,6 +223,7 @@ public class EntityBuilder {
     return new Location()
       .withId(randomId())
       .withName("Specific")
+      .withDiscoveryDisplayName("DiscoveryDisplayName")
       .withCampusId(String.valueOf(campus.getAdditionalProperties().get(KEY_ID)))
       .withLibraryId(String.valueOf(library.getAdditionalProperties().get(KEY_ID)))
       .withInstitutionId(String.valueOf(institution.getAdditionalProperties().get(KEY_ID)));


### PR DESCRIPTION
**Purpose**
This PR serves the purpose to add the value of Item.effectiveLocationDiscoveryDisplayName in the Notice Context which is required as per [https://issues.folio.org/browse/MODFEE-328](url) for Manual fee/fine charge + Manual fee/fine action (pay, waive, refund, transfer or cancel/error).
**Approach**
We already have the field discoveryDisplayName in Location Object so at the time of preparing Notice context
we are adding the above value and set it to the Item Context.
After this change, LocationDiscoveryDisplayName is populated in the Notices. Please find the Email Evidence below
![MODFEE-328-2](https://user-images.githubusercontent.com/127184919/227457372-6e049694-343b-4163-83bf-195086f902e8.JPG)
![MODFEE-328-1](https://user-images.githubusercontent.com/127184919/227457375-0cfefe92-c42d-452b-8b23-6726d80863f4.JPG)
