### PR TITLE
MODFEE-345

### DIFF
--- a/ramls/overdue-fine-policy.json
+++ b/ramls/overdue-fine-policy.json
@@ -44,6 +44,11 @@
       "javaType": "org.folio.rest.domain.MonetaryValue",
       "type": "number"
     },
+    "reminderFeesPolicy" : {
+      "description": "Rules and schedule for reminders with associated fees",
+      "type": "object",
+      "$ref": "reminder-fees-policy.json"
+    },
     "metadata": {
       "description": "Metadata about creation to overdue fine policy, provided by the server",
       "type": "object",

--- a/ramls/overdue-fine-policy.raml
+++ b/ramls/overdue-fine-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Overdue Fine Policies
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/reminder-fees-policy.json
+++ b/ramls/reminder-fees-policy.json
@@ -4,18 +4,6 @@
   "description": "Reminder fee policy as part of overdue fine policy",
   "type": "object",
   "properties": {
-    "countClosed": {
-      "description": "A flag to determine if a reminder fee should take closed days into account",
-      "type": "boolean"
-    },
-    "ignoreGracePeriodRecall": {
-      "description": "Ignore grace period for recall",
-      "type": "boolean"
-    },
-    "clearPatronBlockWhenPaid": {
-      "description": "Clear patron block when paid",
-      "type": "boolean"
-    },
     "reminderSchedule" : {
       "description": "Ordered list of reminder notices",
       "type": "array",
@@ -52,8 +40,11 @@
             "description": "Id of reminder notice template",
             "$ref": "raml-util/schemas/uuid.schema"
           }
-        }
+        },
+        "additionalProperties": false,
+        "required": ["interval", "timeUnitId", "reminderFee", "noticeMethodId", "noticeTemplateId"]
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/ramls/reminder-fees-policy.json
+++ b/ramls/reminder-fees-policy.json
@@ -1,0 +1,59 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title": "Reminder fees policy schema",
+  "description": "Reminder fee policy as part of overdue fine policy",
+  "type": "object",
+  "properties": {
+    "countClosed": {
+      "description": "A flag to determine if a reminder fee should take closed days into account",
+      "type": "boolean"
+    },
+    "ignoreGracePeriodRecall": {
+      "description": "Ignore grace period for recall",
+      "type": "boolean"
+    },
+    "clearPatronBlockWhenPaid": {
+      "description": "Clear patron block when paid",
+      "type": "boolean"
+    },
+    "reminderSchedule" : {
+      "description": "Ordered list of reminder notices",
+      "type": "array",
+      "items": {
+        "description": "Scheduled reminder notice with associated fee",
+        "type": "object",
+        "properties": {
+          "interval": {
+            "description": "Number of units of time before notice should be sent",
+            "type": "integer"
+          },
+          "timeUnitId": {
+            "description": "Time unit of interval",
+            "type": "string",
+            "enum":[
+              "day",
+              "week"
+            ]
+          },
+          "reminderFee": {
+            "description": "Fee amount accrued by reminder notice",
+            "javaType": "org.folio.rest.domain.MonetaryValue",
+            "type": "number"
+          },
+          "noticeMethodId": {
+            "description": "Method of sending notice",
+            "type": "string",
+            "enum": [
+              "email",
+              "mail"
+            ]
+          },
+          "noticeTemplateId": {
+            "description": "Id of reminder notice template",
+            "$ref": "raml-util/schemas/uuid.schema"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -63,6 +63,10 @@
         {
           "fieldName" : "userId",
           "tOps" : "ADD"
+        },
+        {
+          "fieldName" : "typeAction",
+          "tOps" : "ADD"
         }
       ]
     },


### PR DESCRIPTION
PR would add a new optional section "reminderFeesPolicy" to the Overdue Fine Policy Schema.

The PR provides for adding a reminder fees schedule that is meant to kick in when a loan becomes overdue. At this stage, it does not contain any logic for handling any of these settings however. The PR is purely about extending the schema so far.

It's suggested to raised the version of Overdue Fine Policies API from 1.0 to 1.1 due to the new optional element.  