### PR TITLE
MODFEE-375 Upgrade to RMB 35.2.0, Vertx 4.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <powermock.version>2.0.7</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>35.0.2</raml-module-builder.version>
-    <vertx.version>4.3.4</vertx.version>
+    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <vertx.version>4.5.5</vertx.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>
     <!-- Postgres port for Jenkins CI build environment https://issues.folio.org/browse/METADATA-10 -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.23.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <powermock.version>2.0.7</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <vertx.version>4.5.5</vertx.version>
+    <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>
     <!-- Postgres port for Jenkins CI build environment https://issues.folio.org/browse/METADATA-10 -->

--- a/src/main/java/org/folio/rest/impl/ManualBlockTemplatesAPI.java
+++ b/src/main/java/org/folio/rest/impl/ManualBlockTemplatesAPI.java
@@ -6,9 +6,9 @@ import io.vertx.core.Handler;
 
 import java.util.Map;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;

--- a/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/LostItemFeePoliciesAPITest.java
@@ -68,7 +68,7 @@ public class LostItemFeePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must not be null")
       .put("type", "1")
-      .put("code", "javax.validation.constraints.NotNull.message")
+      .put("code", "jakarta.validation.constraints.NotNull.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()
@@ -110,7 +110,7 @@ public class LostItemFeePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must match \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$\"")
       .put("type", "1")
-      .put("code", "javax.validation.constraints.Pattern.message")
+      .put("code", "jakarta.validation.constraints.Pattern.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()

--- a/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OverdueFinePoliciesAPITest.java
@@ -67,7 +67,7 @@ public class OverdueFinePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must not be null")
       .put("type", "1")
-      .put("code", "javax.validation.constraints.NotNull.message")
+      .put("code", "jakarta.validation.constraints.NotNull.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()
@@ -109,7 +109,7 @@ public class OverdueFinePoliciesAPITest extends ApiTests {
     JsonObject error = new JsonObject()
       .put("message", "must match \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$\"")
       .put("type", "1")
-      .put("code", "javax.validation.constraints.Pattern.message")
+      .put("code", "jakarta.validation.constraints.Pattern.message")
       .put("parameters", new JsonArray(Collections.singletonList(parameters)));
 
     String errors = new JsonObject()


### PR DESCRIPTION
Covers [MODFEE-375](https://folio-org.atlassian.net/browse/MODFEE-375)

Upgrade to RMB 35.2.0, Vertx 4.5.5, Spring 6.1.5

According to https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-352, changed javax.validation package to jakarta.validation.