### PR TITLE
[MODFEE-380] Update feefine closed event publishing

### DIFF
--- a/src/main/java/org/folio/rest/domain/LoanRelatedFeeFineClosedEvent.java
+++ b/src/main/java/org/folio/rest/domain/LoanRelatedFeeFineClosedEvent.java
@@ -7,19 +7,13 @@ import io.vertx.core.json.JsonObject;
 
 public final class LoanRelatedFeeFineClosedEvent {
   private final String loanId;
-  private final String feeFineId;
 
-  public LoanRelatedFeeFineClosedEvent(String loanId, String feeFineId) {
+  public LoanRelatedFeeFineClosedEvent(String loanId) {
     this.loanId = loanId;
-    this.feeFineId = feeFineId;
   }
 
   public String getLoanId() {
     return loanId;
-  }
-
-  public String getFeeFineId() {
-    return feeFineId;
   }
 
   public String toJsonString() {
@@ -27,10 +21,10 @@ public final class LoanRelatedFeeFineClosedEvent {
   }
 
   public static LoanRelatedFeeFineClosedEvent forFeeFine(Account feeFine) {
-    return new LoanRelatedFeeFineClosedEvent(feeFine.getLoanId(), feeFine.getId());
+    return new LoanRelatedFeeFineClosedEvent(feeFine.getLoanId());
   }
 
   public static LoanRelatedFeeFineClosedEvent forActualCostRecord(ActualCostRecord actualCostRecord) {
-    return new LoanRelatedFeeFineClosedEvent(actualCostRecord.getLoan().getId(), null);
+    return new LoanRelatedFeeFineClosedEvent(actualCostRecord.getLoan().getId());
   }
 }

--- a/src/main/java/org/folio/rest/domain/LoanRelatedFeeFineClosedEvent.java
+++ b/src/main/java/org/folio/rest/domain/LoanRelatedFeeFineClosedEvent.java
@@ -1,6 +1,5 @@
 package org.folio.rest.domain;
 
-import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.ActualCostRecord;
 
 import io.vertx.core.json.JsonObject;
@@ -18,10 +17,6 @@ public final class LoanRelatedFeeFineClosedEvent {
 
   public String toJsonString() {
     return JsonObject.mapFrom(this).toString();
-  }
-
-  public static LoanRelatedFeeFineClosedEvent forFeeFine(Account feeFine) {
-    return new LoanRelatedFeeFineClosedEvent(feeFine.getLoanId());
   }
 
   public static LoanRelatedFeeFineClosedEvent forActualCostRecord(ActualCostRecord actualCostRecord) {

--- a/src/main/java/org/folio/rest/service/AccountEventPublisher.java
+++ b/src/main/java/org/folio/rest/service/AccountEventPublisher.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.rest.domain.LoanRelatedFeeFineClosedEvent;
 import org.folio.rest.domain.MonetaryValue;
 import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.ActualCostRecord;
@@ -47,6 +48,11 @@ public class AccountEventPublisher {
   public CompletableFuture<Void> publishLoanRelatedFeeFineClosedEvent(Account feeFine) {
     return eventPublisher.publishEvent(LOAN_RELATED_FEE_FINE_CLOSED,
       forFeeFine(feeFine).toJsonString());
+  }
+
+  public CompletableFuture<Void> publishLoanRelatedFeeFineClosedEvent(String loanId) {
+    return eventPublisher.publishEvent(LOAN_RELATED_FEE_FINE_CLOSED,
+      new LoanRelatedFeeFineClosedEvent(loanId).toJsonString());
   }
 
   public CompletableFuture<Void> publishLoanRelatedFeeFineClosedEvent(

--- a/src/main/java/org/folio/rest/service/AccountEventPublisher.java
+++ b/src/main/java/org/folio/rest/service/AccountEventPublisher.java
@@ -3,7 +3,6 @@ package org.folio.rest.service;
 import static org.folio.rest.domain.EventType.FEE_FINE_BALANCE_CHANGED;
 import static org.folio.rest.domain.EventType.LOAN_RELATED_FEE_FINE_CLOSED;
 import static org.folio.rest.domain.LoanRelatedFeeFineClosedEvent.forActualCostRecord;
-import static org.folio.rest.domain.LoanRelatedFeeFineClosedEvent.forFeeFine;
 import static org.folio.rest.utils.JsonHelper.write;
 
 import java.math.BigDecimal;
@@ -43,11 +42,6 @@ public class AccountEventPublisher {
       .withRemaining(new MonetaryValue(BigDecimal.ZERO));
 
     publishAccountBalanceChangeEvent(account);
-  }
-
-  public CompletableFuture<Void> publishLoanRelatedFeeFineClosedEvent(Account feeFine) {
-    return eventPublisher.publishEvent(LOAN_RELATED_FEE_FINE_CLOSED,
-      forFeeFine(feeFine).toJsonString());
   }
 
   public CompletableFuture<Void> publishLoanRelatedFeeFineClosedEvent(String loanId) {

--- a/src/main/java/org/folio/rest/service/AccountUpdateService.java
+++ b/src/main/java/org/folio/rest/service/AccountUpdateService.java
@@ -55,7 +55,7 @@ public class AccountUpdateService {
       eventPublisher.publishAccountBalanceChangeEvent(account);
 
       if (isFeeFineWithLoanClosed(account)) {
-        return eventPublisher.publishLoanRelatedFeeFineClosedEvent(account)
+        return eventPublisher.publishLoanRelatedFeeFineClosedEvent(account.getLoanId())
           .thenApply(notUsed -> responseResult);
       }
 

--- a/src/main/java/org/folio/rest/service/AccountUpdateService.java
+++ b/src/main/java/org/folio/rest/service/AccountUpdateService.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.repository.AccountRepository;
+import org.folio.rest.service.action.context.ActionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,11 +75,15 @@ public class AccountUpdateService {
       .onSuccess(a -> eventPublisher.publishAccountBalanceChangeEvent(account));
   }
 
-  public void publishLoanRelatedFeeFineClosedEvent(String loanId) {
-    eventPublisher.publishLoanRelatedFeeFineClosedEvent(loanId);
+  public void publishLoanRelatedFeeFineClosedEvent(ActionContext actionContext) {
+    actionContext.getAccounts().values().stream()
+      .filter(this::isFeeFineWithLoanClosed)
+      .map(Account::getLoanId)
+      .distinct()
+      .forEach(eventPublisher::publishLoanRelatedFeeFineClosedEvent);
   }
 
-  public boolean isFeeFineWithLoanClosed(Account feeFine) {
+  private boolean isFeeFineWithLoanClosed(Account feeFine) {
     return isFeeFineAssociatedToLoan(feeFine) && isClosedAndHasZeroRemainingAmount(feeFine);
   }
 

--- a/src/main/java/org/folio/rest/service/AccountUpdateService.java
+++ b/src/main/java/org/folio/rest/service/AccountUpdateService.java
@@ -9,17 +9,20 @@ import static org.folio.rest.persist.PgUtil.put;
 import static org.folio.rest.utils.AccountHelper.isClosedAndHasZeroRemainingAmount;
 import static org.folio.rest.utils.MetadataHelper.populateMetadata;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+
 import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.repository.AccountRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 
 public class AccountUpdateService {
   private static final Logger log = LoggerFactory.getLogger(AccountUpdateService.class);
@@ -68,15 +71,14 @@ public class AccountUpdateService {
     populateMetadata(account, headers);
 
     return accountRepository.update(account)
-      .onSuccess(a -> {
-        eventPublisher.publishAccountBalanceChangeEvent(account);
-        if (isFeeFineWithLoanClosed(account)) {
-          eventPublisher.publishLoanRelatedFeeFineClosedEvent(account);
-        }
-      });
+      .onSuccess(a -> eventPublisher.publishAccountBalanceChangeEvent(account));
   }
 
-  private boolean isFeeFineWithLoanClosed(Account feeFine) {
+  public void publishLoanRelatedFeeFineClosedEvent(String loanId) {
+    eventPublisher.publishLoanRelatedFeeFineClosedEvent(loanId);
+  }
+
+  public boolean isFeeFineWithLoanClosed(Account feeFine) {
     return isFeeFineAssociatedToLoan(feeFine) && isClosedAndHasZeroRemainingAmount(feeFine);
   }
 

--- a/src/main/java/org/folio/rest/service/action/ActionService.java
+++ b/src/main/java/org/folio/rest/service/action/ActionService.java
@@ -17,7 +17,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.folio.rest.domain.Action;
 import org.folio.rest.domain.ActionRequest;
@@ -95,18 +94,8 @@ public abstract class ActionService {
       .compose(this::createFeeFineActions)
       .compose(this::publishLogEvents)
       .compose(this::updateAccounts)
-      .compose(this::publishLoanRelatedFeeFineClosedEvent)
-      .compose(this::sendPatronNotice);
-  }
-
-  private Future<ActionContext> publishLoanRelatedFeeFineClosedEvent(ActionContext actionContext) {
-    actionContext.getAccounts().values().stream()
-      .filter(accountUpdateService::isFeeFineWithLoanClosed)
-      .map(Account::getLoanId)
-      .collect(Collectors.toSet())
-      .forEach(accountUpdateService::publishLoanRelatedFeeFineClosedEvent);
-
-    return succeededFuture(actionContext);
+      .compose(this::sendPatronNotice)
+      .onSuccess(accountUpdateService::publishLoanRelatedFeeFineClosedEvent);
   }
 
   private Future<ActionContext> findAccounts(ActionContext context) {

--- a/src/test/java/org/folio/rest/impl/AccountsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AccountsAPITest.java
@@ -15,10 +15,10 @@ import static org.folio.test.support.matcher.AccountMatchers.isPaidFully;
 import static org.folio.test.support.matcher.AccountMatchers.singleAccountMatcher;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -37,12 +37,11 @@ import org.awaitility.Awaitility;
 import org.folio.rest.domain.EventType;
 import org.folio.rest.domain.MonetaryValue;
 import org.folio.rest.jaxrs.model.Account;
+import org.folio.rest.jaxrs.model.ContributorData;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
-import org.folio.rest.jaxrs.model.ItemStatus;
 import org.folio.rest.jaxrs.model.PaymentStatus;
 import org.folio.rest.jaxrs.model.Status;
-import org.folio.rest.jaxrs.model.ContributorData;
 import org.folio.test.support.ApiTests;
 import org.folio.test.support.matcher.TypeMappingMatcher;
 import org.hamcrest.Matcher;
@@ -172,9 +171,7 @@ public class AccountsAPITest extends ApiTests {
 
     assertThat(event, isFeeFineClosedEventPublished());
     assertThat(event.getEventPayload(), allOf(
-      hasJsonPath("loanId", is(loanId)),
-      hasJsonPath("feeFineId", is(accountId))
-    ));
+      hasJsonPath("loanId", is(loanId))));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
@@ -397,7 +397,7 @@ public class AccountsBulkPayWaiveTransferAPITests extends ActionsAPITests {
 
     Awaitility.await()
       .atMost(5, TimeUnit.SECONDS)
-      .untilAsserted(() -> getOkapi().verify(postRequestedFor(urlPathEqualTo("/pubsub/publish"))
+      .untilAsserted(() -> getOkapi().verify(1, postRequestedFor(urlPathEqualTo("/pubsub/publish"))
         .withRequestBody(equalToJson(toJson(event), true, true))
       ));
   }

--- a/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsBulkPayWaiveTransferAPITests.java
@@ -330,8 +330,7 @@ public class AccountsBulkPayWaiveTransferAPITests extends ActionsAPITests {
       .put("loanId", account2.getLoanId()));
 
     verifyThatEventWasSent(EventType.LOAN_RELATED_FEE_FINE_CLOSED, new JsonObject()
-      .put("loanId", account2.getLoanId())
-      .put("feeFineId", account2.getId()));
+      .put("loanId", account2.getLoanId()));
     Awaitility.await()
       .atMost(5, TimeUnit.SECONDS);
 

--- a/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
+++ b/src/test/java/org/folio/rest/impl/AccountsPayWaiveTransferAPITests.java
@@ -312,8 +312,7 @@ public class AccountsPayWaiveTransferAPITests extends ActionsAPITests {
 
     if (terminalAction && account.getLoanId() != null) {
       verifyThatEventWasSent(EventType.LOAN_RELATED_FEE_FINE_CLOSED, new JsonObject()
-        .put("loanId", account.getLoanId())
-        .put("feeFineId", account.getId()));
+        .put("loanId", account.getLoanId()));
     }
 
     assertThat(fetchLogEventPayloads(getOkapi()).get(0),


### PR DESCRIPTION
## Purpose
Steps to Reproduce:
1.  In circulation settings, set the lost item fee policy to charge a flat replacement fee, and a separate lost item processing fee.  Amounts don't matter.
2.  check out an item with this policy attached to a user.  I use barcode 10101 for testing, but i think most items in the system use this policy.
3.  Navigate to the user detail screen for that user and click on loans.  click down to the loan for the item you just checked out.  Declare the item lost. 
4. Go to fees/fines and pay the fine and processing fee for that item.
5.  Go back to loans and check the closed loan details screen for that loan. 

Expected result:

there should be one lost and paid transaction noted in the actions table.

Actual result:

system shows two separate lost and paid actions

Resolves: [MODFEE-380](https://folio-org.atlassian.net/browse/MODFEE-380)