### PR TITLE
MODFEE-399 Add missing required interfaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -49,6 +49,10 @@
     {
       "id": "actual-cost-record-storage",
       "version": "0.7"
+    },
+    {
+      "id": "loan-types",
+      "version": "2.3"
     }
   ],
   "provides":[


### PR DESCRIPTION
MODFEE-399

Add missing required interfaces.

Some required interfaces are not specified in Module Descriptor. This leads to excessive egress request routing though Kong, instead of direct calls to other module sidecars.

Sidecar logs:
`sidecar-mod-feesfines,/loan-types/2b94c631-fca9-4892-a730-03ee529ffe27,14`