### PR TITLE
[MODFEE-405] Fix DeploymentDescriptor-template.json file nodeId value

### DIFF
--- a/descriptors/DeploymentDescriptor-template.json
+++ b/descriptors/DeploymentDescriptor-template.json
@@ -1,6 +1,6 @@
 {
   "srvcId": "${artifactId}-${version}",
-  "nodeId": "10.0.2.15",
+  "nodeId": "localhost",
   "descriptor": {
     "exec": "java -jar ../mod-feesfines/target/mod-feesfines-fat.jar -Dhttp.port=%p"
   }


### PR DESCRIPTION
If we deploy mod-feesfines locally with a local okapi instance, the nodeId value should be "localhost" else it fails, right now its "10.0.2.15".

After checking other folio modules, we found that the convention value for nodeId is "localhost"

Resolves: [MODFEE-405](https://folio-org.atlassian.net/browse/MODFEE-405)