### PR TITLE
MODFEE-413: Fix argLine jacoco code coverage configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <argLine>-Djava.locale.providers=COMPAT</argLine>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>
@@ -513,7 +514,6 @@
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
-          <argLine>-Djava.locale.providers=COMPAT</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODFEE-413

https://github.com/folio-org/mod-feesfines/pull/307/files = https://folio-org.atlassian.net/browse/MODFEE-407 has added the argLine paremeter.

The argLine parameter has incorrectly been added to the maven-surefire-plugin, it should have been added to the global configuration as suggested on https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/393150471/Migration+to+Java+21+and+Spring+Boot+3.4  and https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html .

Therefore the jacoco code coverage doesn’t work for most files.

Fix:

Move argLine from maven-surefire-plugin configuration to global configuration.