### PR TITLE
MODFEE-415: Upgrade wiremock from 2.35.0 to 3.12.1 fixing CVE-2023-41329

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
     <joda-time.version>2.13.1</joda-time.version>
     <mod-pubsub-client.version>2.15.4</mod-pubsub-client.version>
     <rest-assured.version>5.5.1</rest-assured.version>
-    <wiremock.version>2.27.2</wiremock.version>
     <awaitility.version>4.3.0</awaitility.version>
     <json-path-assert.version>2.9.0</json-path-assert.version>
     <JUnitParams.version>1.1.1</JUnitParams.version>
@@ -158,18 +157,6 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>${rest-assured.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>${wiremock.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.sf.jopt-simple</groupId>
-          <artifactId>jopt-simple</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODFEE-415

Dependabot complains that an unsupported wiremock version with security vulnerability is used:

https://github.com/folio-org/mod-feesfines/security/dependabot/2

https://github.com/wiremock/wiremock/security/advisories/GHSA-pmxq-pj47-j8j4 = CVE-2023-41329